### PR TITLE
docs: Add GitHub CLI as prerequisite in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,12 +39,28 @@ HA Boss is a standalone Python service that monitors Home Assistant instances, a
 
 - **Python 3.12** (required for consistency with CI)
 - **uv** (fast Python package installer - https://github.com/astral-sh/uv)
+- **GitHub CLI (gh)** (required for issue/PR management - https://cli.github.com/)
 
 ### Initial Setup
 
 ```bash
 # Install uv if not already installed
 curl -LsSf https://astral.sh/uv/install.sh | sh
+
+# Install GitHub CLI if not already installed
+# macOS
+brew install gh
+# Linux (Debian/Ubuntu)
+curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
+sudo apt update
+sudo apt install gh
+# Windows (via scoop)
+scoop install gh
+
+# Authenticate with GitHub (required for gh commands)
+gh auth login
+# Follow prompts: select HTTPS, authenticate via browser, grant required scopes
 
 # Create virtual environment with Python 3.12
 uv venv --python 3.12


### PR DESCRIPTION
## Summary
Adds GitHub CLI (gh) to the prerequisites section of CLAUDE.md with comprehensive installation instructions. This addresses missing documentation that was preventing proper setup for issue/PR management workflows.

## Problem
- GitHub CLI is used extensively in the Feature Branch Workflow examples (lines 389, 436)
- It's required for `gh issue`, `gh pr`, and `gh project` commands
- Was not documented in Prerequisites section
- Caused failures when Claude Code web tried to pull issues

## Changes
- Added GitHub CLI to Prerequisites list (line 42)
- Added installation instructions for:
  - macOS (Homebrew)
  - Linux/Debian/Ubuntu (apt)
  - Windows (scoop)
- Added `gh auth login` authentication instructions
- Clarified that gh is required for issue/PR management

## Testing
- [x] Verified installation commands are correct for each platform
- [x] Confirmed gh auth login flow is documented
- [x] Checked that all gh commands in workflow examples are now covered

## Related
Part of Issue #8 (Update documentation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)