### PR TITLE
fix: Update Claude workflow permissions to allow PR creation

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write   # Allow commenting on PRs
       issues: read
       id-token: write
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -19,11 +19,11 @@ jobs:
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      pull-requests: read
-      issues: read
+      contents: write        # Allow pushing to branches
+      pull-requests: write   # Allow creating PRs
+      issues: write          # Allow updating issues
       id-token: write
-      actions: read # Required for Claude to read CI results on PRs
+      actions: read          # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
## Problem
The @claude GitHub workflow was completing tasks successfully but **not creating PRs automatically**. Instead, it would push to a branch and provide a "Create PR" link in a comment.

For example, when @claude was mentioned on Issue #3, it:
- ✅ Implemented the feature
- ✅ Wrote tests  
- ✅ Committed and pushed to `claude/issue-3-20251102-1942`
- ✅ Commented on the issue with a summary
- ❌ Did NOT create the PR (provided a link instead)

## Root Cause
The workflow had read-only permissions:
```yaml
permissions:
  contents: read
  pull-requests: read
  issues: read
```

## Solution
Updated both Claude workflows with write permissions:

### `claude.yml` (main @claude workflow)
```yaml
permissions:
  contents: write        # Allow branch creation and pushes
  pull-requests: write   # Allow automatic PR creation  
  issues: write          # Allow issue updates
```

### `claude-code-review.yml` (automatic code reviews)
```yaml
permissions:
  pull-requests: write   # Allow posting review comments
```

## Impact
After this change, the @claude workflow will be fully automated:
1. User mentions @claude on an issue
2. Claude implements the feature
3. Claude pushes to a branch
4. **Claude automatically creates a PR** (NEW!)
5. Claude can update issue acceptance criteria (NEW!)
6. Code review workflow can comment on PRs (NEW!)

## Testing
- [x] Verified permissions are correct according to GitHub Actions docs
- [x] Checked that write permissions are safe (limited to repository scope)
- [ ] Will test by mentioning @claude on another issue after merge

## Security Considerations
These permissions are scoped to the repository and the `CLAUDE_CODE_OAUTH_TOKEN` secret. The workflow only runs when explicitly triggered by @claude mentions, providing controlled automation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)