### PR TITLE
test: fix HomeAssistantClient tests for multi-instance support

### DIFF
--- a/tests/core/test_ha_client.py
+++ b/tests/core/test_ha_client.py
@@ -28,13 +28,15 @@ def mock_config():
 @pytest.fixture
 def client(mock_config):
     """Create HA client instance."""
-    return HomeAssistantClient(mock_config)
+    instance = mock_config.home_assistant.get_default_instance()
+    return HomeAssistantClient(instance, mock_config)
 
 
 @pytest.mark.asyncio
 async def test_client_init(mock_config):
     """Test client initialization."""
-    client = HomeAssistantClient(mock_config)
+    instance = mock_config.home_assistant.get_default_instance()
+    client = HomeAssistantClient(instance, mock_config)
     assert client.base_url == "http://homeassistant.local:8123"
     assert client.token == "test_token"
     assert client._session is None
@@ -61,7 +63,8 @@ async def test_close_session(client):
 @pytest.mark.asyncio
 async def test_context_manager(mock_config):
     """Test async context manager."""
-    async with HomeAssistantClient(mock_config) as client:
+    instance = mock_config.home_assistant.get_default_instance()
+    async with HomeAssistantClient(instance, mock_config) as client:
         assert client._session is not None
         assert not client._session.closed
 


### PR DESCRIPTION
## Summary

Fixed 23 failing tests in `test_ha_client.py` by updating HomeAssistantClient instantiations to use the new multi-instance signature.

## Changes

- Updated `client` fixture to get instance from `config.home_assistant.get_default_instance()`
- Updated `test_client_init` to pass instance parameter
- Updated `test_context_manager` to pass instance parameter

## Impact

**Before**: 23 tests failing with `TypeError: HomeAssistantClient.__init__() missing 1 required positional argument`

**After**: All 23 tests passing ✅

## Testing

```bash
pytest tests/core/test_ha_client.py -v
# ====== 23 passed in 0.38s ======
```

## PR Size Metrics

Following new PR scope guidelines from CONTRIBUTING.md:
- ✅ **Files Changed**: 1 (< 10 limit)
- ✅ **Lines Changed**: 9 (< 500 limit)
- ✅ **Single Component**: test_ha_client.py only
- ✅ **Review Time**: < 5 minutes

## Related Issues

Part of incremental test fixes following PR #115 (multi-instance refactor). This is the first of several focused PRs to fix remaining test failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)