### PR TITLE
test: fix PatternCollector tests for multi-instance support

### DIFF
--- a/tests/intelligence/test_pattern_collector.py
+++ b/tests/intelligence/test_pattern_collector.py
@@ -51,13 +51,13 @@ async def test_database(tmp_path):
 @pytest.fixture
 def pattern_collector(mock_config, test_database):
     """Create PatternCollector instance."""
-    return PatternCollector(mock_config, test_database)
+    return PatternCollector("default", mock_config, test_database)
 
 
 @pytest.fixture
 def pattern_collector_disabled(mock_config_disabled, test_database):
     """Create PatternCollector instance with collection disabled."""
-    return PatternCollector(mock_config_disabled, test_database)
+    return PatternCollector("default", mock_config_disabled, test_database)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Fixed 10 tests in `test_pattern_collector.py` by adding `instance_id` parameter to PatternCollector fixtures.

## Changes

- Updated `pattern_collector` fixture to pass `instance_id="default"`
- Updated `pattern_collector_disabled` fixture to pass `instance_id="default"`

## Impact

**Before**: 10 tests failing with `TypeError: PatternCollector.__init__() missing 1 required positional argument`

**After**: All 10 tests passing ✅

## Testing

```bash
pytest tests/intelligence/test_pattern_collector.py -v
# ====== 10 passed in 0.99s ======
```

## PR Size Metrics

Following new PR scope guidelines from CONTRIBUTING.md:
- ✅ **Files Changed**: 1 (< 10 limit)
- ✅ **Lines Changed**: 4 (< 500 limit)
- ✅ **Single Component**: pattern_collector only
- ✅ **Review Time**: < 3 minutes

## Related Issues

Part of incremental test fixes following PR #115 (multi-instance refactor). Fourth in series of focused PRs to fix remaining test failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)