### PR TITLE
fix: add atomic instance switching to prevent race conditions

### DIFF
--- a/ha_boss/api/routes/websocket.py
+++ b/ha_boss/api/routes/websocket.py
@@ -74,14 +74,9 @@ async def websocket_endpoint(
                     )
 
                 elif message_type == "switch_instance":
-                    # Switch to different instance
+                    # Switch to different instance atomically to avoid race conditions
                     new_instance_id = message.get("instance_id", "default")
-
-                    # Disconnect from current instance
-                    await manager.disconnect(websocket)
-
-                    # Connect to new instance
-                    await manager.connect(websocket, new_instance_id)
+                    await manager.switch_instance(websocket, new_instance_id)
 
                 else:
                     logger.warning(f"Unknown message type from {id(websocket)}: {message_type}")

--- a/tests/api/test_websocket.py
+++ b/tests/api/test_websocket.py
@@ -226,3 +226,174 @@ class TestWebSocketManager:
 
         # Check subscriptions were updated
         assert manager._connections[ws]["subscriptions"] == {"status", "entities"}
+
+    @pytest.mark.asyncio
+    async def test_switch_instance(self) -> None:
+        """Test switching WebSocket connection between instances."""
+        manager = WebSocketManager()
+
+        # Mock WebSocket
+        ws = MagicMock(spec=WebSocket)
+        send_calls = []
+
+        async def mock_send(data: dict) -> None:
+            send_calls.append(data)
+
+        ws.send_json = mock_send
+
+        # Connect to default instance
+        await manager.connect(ws, "default")
+
+        # Switch to home instance
+        await manager.switch_instance(ws, "home")
+
+        # Check connection is now on home instance
+        assert manager._connections[ws]["instance_id"] == "home"
+        assert ws in manager._instance_subscriptions["home"]
+        assert ws not in manager._instance_subscriptions.get("default", set())
+
+        # Check instance_switched message was sent
+        assert len(send_calls) == 2  # connect + switch
+        switch_msg = send_calls[1]
+        assert switch_msg["type"] == "instance_switched"
+        assert switch_msg["old_instance_id"] == "default"
+        assert switch_msg["new_instance_id"] == "home"
+
+    @pytest.mark.asyncio
+    async def test_switch_instance_same_instance(self) -> None:
+        """Test switching to the same instance is a no-op."""
+        manager = WebSocketManager()
+
+        # Mock WebSocket
+        ws = MagicMock(spec=WebSocket)
+        send_calls = []
+
+        async def mock_send(data: dict) -> None:
+            send_calls.append(data)
+
+        ws.send_json = mock_send
+
+        # Connect to default instance
+        await manager.connect(ws, "default")
+
+        # Switch to same instance (should be no-op)
+        await manager.switch_instance(ws, "default")
+
+        # Check still on default instance
+        assert manager._connections[ws]["instance_id"] == "default"
+        assert ws in manager._instance_subscriptions["default"]
+
+        # Only connect message, no switch message
+        assert len(send_calls) == 1
+
+    @pytest.mark.asyncio
+    async def test_switch_instance_race_condition_protection(self) -> None:
+        """Test that instance switching is atomic and prevents race conditions.
+
+        This test simulates a broadcast happening during instance switch to ensure
+        the atomic lock prevents message loss or messages sent to wrong instance.
+        """
+        import asyncio
+
+        manager = WebSocketManager()
+
+        # Mock WebSocket
+        ws = MagicMock(spec=WebSocket)
+        send_calls = []
+
+        async def mock_send(data: dict) -> None:
+            send_calls.append(data)
+
+        ws.send_json = mock_send
+
+        # Connect to default instance
+        await manager.connect(ws, "default")
+
+        # Create a flag to track when switch starts
+        switch_started = False
+        broadcast_sent = False
+
+        async def broadcast_during_switch() -> None:
+            """Broadcast messages during instance switch."""
+            nonlocal broadcast_sent
+            # Wait for switch to start
+            while not switch_started:
+                await asyncio.sleep(0.001)
+            # Try to broadcast to default instance (should not reach ws)
+            await manager.broadcast_entity_state(
+                instance_id="default",
+                entity_id="sensor.test_default",
+                state={"state": "on"},
+            )
+            broadcast_sent = True
+
+        # Start broadcast task
+        broadcast_task = asyncio.create_task(broadcast_during_switch())
+
+        # Perform switch (which should be atomic)
+        switch_started = True
+        await manager.switch_instance(ws, "home")
+
+        # Wait for broadcast to complete
+        await broadcast_task
+
+        # Verify switch completed
+        assert manager._connections[ws]["instance_id"] == "home"
+        assert ws in manager._instance_subscriptions["home"]
+        assert ws not in manager._instance_subscriptions.get("default", set())
+
+        # Check messages sent
+        # Should have: connect message, switch message
+        # Should NOT have: broadcast message (since ws switched away from default)
+        assert broadcast_sent, "Broadcast should have been sent"
+
+        # Count message types
+        message_types = [msg["type"] for msg in send_calls]
+        assert "connected" in message_types
+        assert "instance_switched" in message_types
+        # The broadcast to default should NOT appear since we switched to home
+        assert message_types.count("entity_state_changed") == 0
+
+    @pytest.mark.asyncio
+    async def test_switch_instance_unknown_websocket(self) -> None:
+        """Test switching instance for unknown websocket logs warning."""
+        manager = WebSocketManager()
+
+        # Mock WebSocket that's not connected
+        ws = MagicMock(spec=WebSocket)
+
+        async def mock_send(data: dict) -> None:
+            pass
+
+        ws.send_json = mock_send
+
+        # Try to switch (should log warning and return)
+        await manager.switch_instance(ws, "home")
+
+        # Verify no crash and no subscriptions created
+        assert ws not in manager._connections
+        assert "home" not in manager._instance_subscriptions
+
+    @pytest.mark.asyncio
+    async def test_switch_instance_preserves_subscriptions(self) -> None:
+        """Test that switching instances preserves client subscriptions."""
+        manager = WebSocketManager()
+
+        # Mock WebSocket
+        ws = MagicMock(spec=WebSocket)
+
+        async def mock_send(data: dict) -> None:
+            pass
+
+        ws.send_json = mock_send
+
+        # Connect and update subscriptions
+        await manager.connect(ws, "default")
+        await manager.update_subscription(ws, {"entities", "health"})
+
+        # Switch instance
+        await manager.switch_instance(ws, "home")
+
+        # Check subscriptions are preserved
+        assert manager._connections[ws]["subscriptions"] == {"entities", "health"}
+        assert manager._connections[ws]["instance_id"] == "home"


### PR DESCRIPTION
## Summary

Implements atomic instance switching for WebSocket connections to fix race condition identified in Issue #154. Previously, instance switching used a disconnect+reconnect pattern that could lose messages or send them to the wrong instance during the gap.

### Changes Made

**Atomic Switch Implementation:**
- Added `switch_instance()` method to `WebSocketManager` that holds the lock throughout the entire operation
- Ensures no broadcasts can occur during instance transition
- Sends confirmation message after switch completes successfully

**Route Update:**
- Updated `/api/ws` endpoint to use atomic `manager.switch_instance()` instead of manual disconnect+reconnect
- Simplified code from 4 lines to 1 line with better safety guarantees

**Comprehensive Test Coverage (5 new tests):**
- Basic instance switching - verifies switch works correctly
- Same instance no-op - switching to current instance does nothing  
- Race condition protection - concurrent broadcast during switch handled correctly
- Unknown websocket handling - logs warning and returns safely
- Subscription preservation - client subscriptions maintained during switch

### Problem Solved

**Before:**
```python
# Disconnect from current instance
await manager.disconnect(websocket)

# Connect to new instance
await manager.connect(websocket, new_instance_id)
```

During the gap between disconnect and connect, a broadcast could:
- Be sent to the old instance after disconnect (lost message)
- Be sent to new instance before connect (lost message)
- See inconsistent state (wrong routing)

**After:**
```python
await manager.switch_instance(websocket, new_instance_id)
```

The entire operation is atomic - no other operations can interleave.

### Test Results

✅ All 5 new instance switching tests pass
✅ No regressions in existing WebSocket tests  
✅ Code formatted with black
✅ Linting passes with ruff

### Technical Details

The `switch_instance()` method:
1. Acquires the manager lock
2. Validates the websocket exists
3. Checks if already on target instance (no-op)
4. Removes from old instance subscriptions
5. Updates connection info
6. Adds to new instance subscriptions
7. Releases lock
8. Sends confirmation message (outside lock to avoid deadlock)

The confirmation message allows clients to know when the switch completes successfully.

## Related Issues

Closes #154

🤖 Generated with [Claude Code](https://claude.com/claude-code)