### PR TITLE
feat: implement outcome validation service for automations

### DIFF
--- a/tests/automation/test_outcome_validator.py
+++ b/tests/automation/test_outcome_validator.py
@@ -396,6 +396,21 @@ class TestOutcomeValidator:
         actual = {"brightness": 110}  # 10% difference
         assert validator._compare_attributes(desired, actual) is False
 
+    def test_compare_attributes_zero_value_tolerance(self, validator):
+        """Test numeric attribute comparison with zero desired value."""
+        # Zero value should use minimum absolute tolerance (1.0)
+        desired = {"brightness": 0}
+        actual = {"brightness": 0}  # Exact match
+        assert validator._compare_attributes(desired, actual) is True
+
+        # Within minimum tolerance (1.0)
+        actual = {"brightness": 1}
+        assert validator._compare_attributes(desired, actual) is True
+
+        # Outside minimum tolerance
+        actual = {"brightness": 2}
+        assert validator._compare_attributes(desired, actual) is False
+
     def test_compare_attributes_missing_key(self, validator):
         """Test attribute comparison when key is missing."""
         desired = {"brightness": 100, "color_temp": 300}


### PR DESCRIPTION
## Summary

Implement outcome validation service that validates whether automation executions achieved their desired outcomes by comparing expected entity states to actual states within a time window. Includes pattern learning to improve confidence scores over time.

This is the next phase of the Goal-Oriented Healing Architecture, building on the desired state inference from #185.

## Changes

### New Service (`ha_boss/automation/outcome_validator.py`)
- `OutcomeValidator` class for validating automation execution outcomes
- `validate_execution()` method:
  - Queries `AutomationDesiredState` for expected outcomes
  - Queries HA history API for actual states in validation window (default 5s)
  - Compares expected vs actual for each target entity
  - Returns `ValidationResult` with per-entity and overall success status
  - Calculates `time_to_achievement_ms` (latency between execution and state achievement)
  - Stores results in `AutomationOutcomeValidation` table

### Pattern Learning
- Records successful outcomes in `AutomationOutcomePattern` table
- Increments `occurrence_count` for repeated successful patterns
- Updates confidence scores in `AutomationDesiredState`:
  - Formula: `min(1.0, 0.5 + (occurrence_count * 0.1))`
  - Higher occurrence count → higher confidence
  - Caps at 1.0 (100% confidence)

### Validation Logic
- **State Comparison**: Case-insensitive matching ("on" == "ON")
- **Attribute Comparison**: 
  - Numeric values: 5% tolerance (e.g., brightness 100 ± 5)
  - Non-numeric values: Exact match required
- **Edge Cases**:
  - No history available → validation fails
  - Partial success (some entities succeed, others fail) → overall_success = False
  - Missing desired states → skip validation with warning
  - Multiple state changes in window → uses last state

### Data Classes
- `EntityValidationResult`: Per-entity validation outcome
  - `entity_id`, `desired_state`, `actual_state`
  - `achieved` boolean, `time_to_achievement_ms`
- `ValidationResult`: Overall validation outcome
  - `overall_success`, `entity_results` dict, `validated_at` timestamp

### Tests (`tests/automation/test_outcome_validator.py`)
- 19 comprehensive tests covering:
  - Successful validation (all entities reach desired state)
  - Partial failure (some entities fail)
  - Complete failure (no entities succeed)
  - No history available
  - Execution not found (error handling)
  - No desired states (graceful skip)
  - Time-to-achievement calculation
  - State comparison (case-insensitive)
  - Attribute comparison (exact and numeric tolerance)
  - Pattern learning (new and existing patterns)
  - Confidence score updates
  - Validation window configuration

## Test Results

All 19 tests pass with **94% code coverage**:

```bash
pytest tests/automation/test_outcome_validator.py --cov=ha_boss.automation.outcome_validator
# 19 passed, 94% coverage
```

## Code Quality

- ✅ Black formatting passed
- ✅ Ruff linting passed
- ✅ Mypy type checking passed (no new errors)
- ✅ Coverage: 94% (far exceeds 80% requirement)

## Example Usage

```python
from ha_boss.automation.outcome_validator import OutcomeValidator

validator = OutcomeValidator(database, ha_client, "default")

# Validate automation execution #123
result = await validator.validate_execution(
    execution_id=123,
    validation_window_seconds=5.0
)

if result.overall_success:
    print("All entities reached desired states!")
    for entity_id, entity_result in result.entity_results.items():
        print(f"{entity_id}: achieved in {entity_result.time_to_achievement_ms}ms")
else:
    print("Some entities failed:")
    for entity_id, entity_result in result.entity_results.items():
        if not entity_result.achieved:
            print(f"{entity_id}: expected {entity_result.desired_state}, "
                  f"got {entity_result.actual_state}")
```

## Pattern Learning Example

After 5 successful validations of the same automation:
- `AutomationOutcomePattern.occurrence_count` = 5
- Updated confidence in `AutomationDesiredState`:
  - `new_confidence = min(1.0, 0.5 + (5 * 0.1)) = 1.0`
  - Confidence increases from initial AI inference (~0.7-0.9) to 1.0 (fully validated)

## Dependencies

- Depends on: #184 (database schema - merged ✅)
- Depends on: #185 (desired state inference - merged ✅)
- Part of: #177 (Epic: Goal-Oriented Healing Architecture)

## Next Steps

After this PR merges, the following PRs will build on this foundation:
1. #181: Integrate outcome validation with automation tracker
2. #182: Add API endpoints for desired states and validation results
3. #183: Add report-failure endpoint for user-reported failures

## Related Issues

Closes #180

🤖 Generated with [Claude Code](https://claude.com/claude-code) using ecomode