### PR TITLE
feat: integrate outcome validation with automation tracker

### DIFF
--- a/ha_boss/core/config.py
+++ b/ha_boss/core/config.py
@@ -441,6 +441,21 @@ class IntelligenceConfig(BaseSettings):
     )
 
 
+class OutcomeValidationConfig(BaseSettings):
+    """Outcome validation configuration."""
+
+    enabled: bool = Field(
+        default=True,
+        description="Enable automatic outcome validation for automations",
+    )
+    validation_delay_seconds: float = Field(
+        default=5.0,
+        description="Delay before validating outcomes (allows states to settle)",
+        ge=0.1,
+        le=60.0,
+    )
+
+
 class APIConfig(BaseModel):
     """REST API configuration."""
 
@@ -500,6 +515,7 @@ class Config(BaseSettings):
     websocket: WebSocketConfig = Field(default_factory=WebSocketConfig)
     rest: RESTConfig = Field(default_factory=RESTConfig)
     intelligence: IntelligenceConfig = Field(default_factory=IntelligenceConfig)
+    outcome_validation: OutcomeValidationConfig = Field(default_factory=OutcomeValidationConfig)
     api: APIConfig = Field(default_factory=APIConfig)
 
     mode: Literal["production", "dry_run", "testing"] = Field(


### PR DESCRIPTION
Summary

Integrate the outcome validation service with the existing automation tracker to automatically validate automation outcomes after execution. This completes Phase 2 of the Goal-Oriented Healing Architecture.

Changes

Configuration (ha_boss/core/config.py)
- Added OutcomeValidationConfig class with:
  - enabled: bool (default True) - Enable/disable automatic validation
  - validation_delay_seconds: float (default 5.0) - Delay before validating to allow states to settle
  
AutomationTracker Integration (ha_boss/monitoring/automation_tracker.py)
- Updated __init__ to accept optional ha_client and config parameters
- Modified record_execution() to return execution_id after successful recording
- Added _validate_execution_outcome() background task method:
  - Waits for validation_delay_seconds before validating
  - Creates OutcomeValidator instance
  - Calls validate_execution() with execution_id
  - Logs results: debug for success, warning for validation failures
  - Graceful error handling - exceptions logged but don't crash tracker

Validation Trigger Logic
- Only triggers for successful executions (success=True)
- Only when config.outcome_validation.enabled=True
- Only when ha_client is available
- Runs in background via asyncio.create_task() - non-blocking
- Uses configured validation_delay_seconds as validation window

Tests (tests/monitoring/test_automation_tracker.py)
Added 8 comprehensive tests:
- test_record_execution_returns_id - Verify execution_id is returned
- test_outcome_validation_triggered - Validation is called with correct parameters
- test_outcome_validation_non_blocking - Validation runs in background without blocking
- test_outcome_validation_disabled - Config disabled skips validation
- test_outcome_validation_failed_execution - Failed executions don't trigger validation
- test_outcome_validation_no_ha_client - Missing ha_client skips validation
- test_outcome_validation_error_handling - Validation errors don't crash tracker
- test_outcome_validation_warning_logged_on_failure - Failed validations log warnings

Test Results

All 21 tests passing (13 existing + 8 new):

pytest tests/monitoring/test_automation_tracker.py -v
# 21 passed in 2.66s


Code Quality

- Black formatting passed
- Ruff linting passed
- Mypy type checking passed (no new errors)
- All existing tests still pass

Example Usage

from ha_boss.monitoring.automation_tracker import AutomationTracker
from ha_boss.core.config import Config

# Initialize tracker with validation
tracker = AutomationTracker(
    instance_id="default",
    database=database,
    ha_client=ha_client,
    config=config  # outcome_validation.enabled = True
)

# Record execution - validation triggers automatically in background
execution_id = await tracker.record_execution(
    automation_id="automation.morning_routine",
    trigger_type="time",
    success=True
)

# Validation runs 5 seconds later (configurable)
# Results logged automatically
# No blocking - execution returns immediately


Logging Behavior

Successful validation (DEBUG):
[default] Execution 123 validated: 2 entities achieved desired states


Failed validation (WARNING):
[default] Execution 123 validation failed: 1/2 entities did not achieve desired states (light.bedroom)


Validation error (ERROR):
[default] Outcome validation failed for execution 123: Connection timeout


Dependencies

- Depends on: #184 (database schema - merged)
- Depends on: #185 (desired state inference - merged)
- Depends on: #186 (outcome validator - merged)
- Part of: #177 (Epic: Goal-Oriented Healing Architecture)

Next Steps

After this PR merges:
- #182: Add API endpoints for desired states and validation results
- #183: Add report-failure endpoint for user-reported failures

Related Issues

Closes #181

Generated with Claude Code using ecomode