### PR TITLE
feat: Add report-failure endpoint for user-reported automation failures (Issue #183)

### DIFF
--- a/ha_boss/api/models.py
+++ b/ha_boss/api/models.py
@@ -523,3 +523,50 @@ class InferredStateResponse(BaseModel):
     desired_state: str = Field(..., description="Inferred state")
     desired_attributes: dict[str, Any] | None = Field(None, description="Inferred attributes")
     confidence: float = Field(..., description="AI confidence score (0.0-1.0)")
+
+
+# Failure Reporting Models
+
+
+class FailureReportRequest(BaseModel):
+    """Request to report an automation failure."""
+
+    execution_id: int | None = Field(None, description="Specific execution ID (optional)")
+    failed_entities: list[str] | None = Field(
+        None, description="List of entities that failed (optional)"
+    )
+    user_description: str | None = Field(None, description="User's description of what went wrong")
+
+
+class EntityFailureDetail(BaseModel):
+    """Details about a failed entity state."""
+
+    entity_id: str = Field(..., description="Entity that failed")
+    desired_state: str | None = Field(None, description="Expected state")
+    actual_state: str | None = Field(None, description="Actual state at validation time")
+    root_cause: str | None = Field(None, description="Suspected root cause")
+
+
+class AIFailureAnalysis(BaseModel):
+    """AI-generated analysis of automation failure."""
+
+    root_cause: str = Field(..., description="AI-identified root cause of failure")
+    suggested_healing: list[str] = Field(..., description="List of suggested healing actions")
+    healing_level: Literal["entity", "device", "integration"] = Field(
+        ..., description="Level at which healing should be applied"
+    )
+
+
+class FailureReportResponse(BaseModel):
+    """Response from failure report with validation and AI analysis."""
+
+    execution_id: int = Field(..., description="Execution ID that was validated")
+    automation_id: str = Field(..., description="Automation ID")
+    overall_success: bool = Field(..., description="Whether validation passed")
+    failed_entities: list[EntityFailureDetail] = Field(
+        ..., description="Details of failed entities"
+    )
+    ai_analysis: AIFailureAnalysis | None = Field(
+        None, description="AI-generated analysis (if enabled)"
+    )
+    user_description: str | None = Field(None, description="User's reported description")

--- a/ha_boss/core/config.py
+++ b/ha_boss/core/config.py
@@ -454,6 +454,10 @@ class OutcomeValidationConfig(BaseSettings):
         ge=0.1,
         le=60.0,
     )
+    analyze_failures: bool = Field(
+        default=True,
+        description="Enable AI analysis of reported automation failures",
+    )
 
 
 class APIConfig(BaseModel):


### PR DESCRIPTION
## Summary

Implements POST `/api/automations/{automation_id}/report-failure` endpoint for users to report automation failures and receive AI-powered analysis, completing Epic #177 Goal-Oriented Healing Architecture.

Closes #183

## Changes

### New API Endpoint

**POST `/api/automations/{automation_id}/report-failure`**

Allows users to report automation failures and receive:
- Retroactive outcome validation results
- AI-powered failure analysis (when enabled)
- Suggested healing actions

**Request Body** (all fields optional):
```json
{
  "execution_id": 123,
  "failed_entities": ["media_player.apple_tv"],
  "user_description": "TV didn't turn on when automation ran"
}
```

**Response**:
```json
{
  "execution_id": 123,
  "automation_id": "automation.watch_apple_tv",
  "overall_success": false,
  "failed_entities": [
    {
      "entity_id": "media_player.apple_tv",
      "desired_state": "playing",
      "actual_state": "off",
      "root_cause": null
    }
  ],
  "ai_analysis": {
    "root_cause": "Wake-on-LAN packets may be failing to reach device",
    "suggested_healing": [
      "Retry WoL magic packet with 2s delay",
      "Check network connectivity to device",
      "Verify device MAC address in integration config"
    ],
    "healing_level": "device"
  },
  "user_description": "TV didn't turn on when automation ran"
}
```

**Features**:
- If no `execution_id` provided, automatically finds most recent execution
- Triggers `OutcomeValidator.validate_execution()` retroactively
- Conditionally runs AI analysis based on configuration
- Gracefully degrades when AI not configured
- Multi-instance support via `instance_id` parameter

### New Pydantic Models

Added 4 models to `ha_boss/api/models.py`:
- **FailureReportRequest**: Request with optional execution_id, failed_entities, user_description
- **EntityFailureDetail**: Failed entity details with desired/actual states, root cause
- **AIFailureAnalysis**: Root cause, suggested healing actions, healing level
- **FailureReportResponse**: Complete response with validation + AI analysis

### New Configuration Option

**OutcomeValidationConfig.analyze_failures** (default: True)
- Controls whether AI analysis runs on reported failures
- When false, only validation is performed
- When true and AI configured, provides analysis and suggestions

### AI Failure Analysis

Added `OutcomeValidator.analyze_failure()` method:
- Analyzes failed entities, automation config, and user description
- Uses LLM router with TaskComplexity.MODERATE
- Builds comprehensive prompt with context:
  - Failed entities (desired vs actual states)
  - Automation YAML configuration
  - User's description of the failure
  - Common failure patterns (device, integration, timing, config)
- Returns structured analysis:
  - Root cause explanation
  - 2-4 specific healing actions
  - Healing level (entity/device/integration)
- Graceful fallback when AI unavailable

### Error Handling

- **404**: Instance not found or no execution found
- **503**: Service not initialized  
- **500**: Internal errors (logged with traceback)
- AI analysis failures don't break endpoint (graceful degradation)

## Testing

Created 8 comprehensive tests in `tests/api/test_automations_routes.py`:

1. ✅ **test_report_failure_with_execution_id** - Report with specific execution
2. ✅ **test_report_failure_without_execution_id** - Finds most recent execution
3. ✅ **test_report_failure_ai_analysis_enabled** - AI analysis runs when enabled
4. ✅ **test_report_failure_ai_analysis_disabled** - AI skipped when disabled
5. ✅ **test_report_failure_instance_not_found** - Returns 404 for invalid instance
6. ✅ **test_report_failure_no_execution_found** - Returns 404 when no execution
7. ✅ **test_report_failure_ai_not_configured** - Works without AI (validation only)
8. ✅ **test_report_failure_response_structure** - Validates complete response

**All 24 tests passing** (16 existing + 8 new)

## Code Quality

- ✅ Black formatting applied
- ✅ Ruff linting passed  
- ✅ Type hints throughout
- ✅ Comprehensive docstrings

## Testing Instructions

1. Start HA Boss with AI configured (Ollama or Claude)
2. Record an automation execution (trigger any automation)
3. Report failure:
   ```bash
   curl -X POST http://localhost:8000/api/automations/automation.test/report-failure?instance_id=default \
     -H "Content-Type: application/json" \
     -d '{
       "user_description": "Light didn't turn on as expected"
     }'
   ```
4. Verify response includes:
   - Validation results with failed entities
   - AI analysis with root cause and suggestions
   - User description echoed back

5. Test without AI:
   - Set `outcome_validation.analyze_failures: false` in config
   - Report failure again
   - Verify `ai_analysis` is null in response

## Related Issues

Part of Epic #177: Goal-Oriented Healing Architecture
- ✅ #178: Add database schema for automation outcome validation (PR #177)
- ✅ #179: AI-based desired state inference (PR #185)
- ✅ #180: Outcome validation service (PR #186)
- ✅ #181: Integrate outcome validation with automation tracker (PR #187)
- ✅ #182: Add API endpoints for automation desired states (PR #188)
- ✅ #183: Add report-failure endpoint (this PR)

**Epic #177 is now COMPLETE!** 🎉

## Impact

- No breaking changes
- Adds new endpoint for user-driven failure reporting
- Enables feedback loop: user reports → AI analysis → healing suggestions
- Completes goal-oriented healing architecture foundation

🤖 Generated with [Claude Code](https://claude.com/claude-code)