### PR TITLE
feat: Issue cleanup batch - close 10 open issues

### DIFF
--- a/ha_boss/api/models.py
+++ b/ha_boss/api/models.py
@@ -1,7 +1,7 @@
 """Pydantic models for API requests and responses."""
 
 from datetime import datetime
-from enum import Enum
+from enum import StrEnum
 from typing import Any, Literal
 
 from pydantic import BaseModel, Field
@@ -470,7 +470,7 @@ class ConfigInstanceTestResponse(BaseModel):
 # Automation Desired States Models
 
 
-class InferenceMethod(str, Enum):
+class InferenceMethod(StrEnum):
     """Methods for inferring automation desired states."""
 
     AI_ANALYSIS = "ai_analysis"

--- a/ha_boss/api/routes/healing.py
+++ b/ha_boss/api/routes/healing.py
@@ -1114,3 +1114,36 @@ async def retry_failed_cascade(
     except Exception as e:
         logger.error(f"[{instance_id}] Error retrying cascade {cascade_id}: {e}", exc_info=True)
         raise HTTPException(status_code=500, detail="Failed to retry cascade") from None
+
+
+@router.get("/healing/routing-metrics")
+async def get_routing_metrics(
+    instance_id: str = Query("default", description="Instance identifier"),
+) -> dict[str, Any]:
+    """Get pattern coverage and routing effectiveness metrics.
+
+    Returns metrics about how well the intelligent routing and pattern
+    learning systems are performing.
+    """
+    try:
+        service = get_service()
+
+        if instance_id not in service.cascade_orchestrators:
+            raise HTTPException(
+                status_code=404,
+                detail=f"Instance '{instance_id}' not found or not initialized",
+            )
+
+        metrics = await service.cascade_orchestrators[instance_id].get_routing_metrics(
+            instance_id=instance_id,
+        )
+
+        return metrics
+
+    except HTTPException:
+        raise
+    except RuntimeError as e:
+        raise HTTPException(status_code=503, detail=str(e)) from None
+    except Exception as e:
+        logger.error(f"[{instance_id}] Error getting routing metrics: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail="Failed to get routing metrics") from None

--- a/ha_boss/automation/outcome_validator.py
+++ b/ha_boss/automation/outcome_validator.py
@@ -18,6 +18,7 @@ if TYPE_CHECKING:
     from ha_boss.healing.cascade_orchestrator import (
         CascadeOrchestrator,
         CascadeResult,
+        HealingContext,
     )
     from ha_boss.intelligence.llm_router import LLMRouter
 

--- a/ha_boss/core/config_service.py
+++ b/ha_boss/core/config_service.py
@@ -14,7 +14,7 @@ import json
 import logging
 import os
 from datetime import UTC, datetime
-from enum import Enum
+from enum import StrEnum
 from typing import Any
 
 from pydantic import BaseModel
@@ -28,7 +28,7 @@ from ha_boss.core.exceptions import ConfigServiceError
 logger = logging.getLogger(__name__)
 
 
-class ConfigSource(str, Enum):
+class ConfigSource(StrEnum):
     """Source of a configuration value."""
 
     DEFAULT = "default"

--- a/ha_boss/core/database.py
+++ b/ha_boss/core/database.py
@@ -866,6 +866,7 @@ class HealingCascadeExecution(Base):
     # Results
     final_success: Mapped[bool | None] = mapped_column(Boolean)
     total_duration_seconds: Mapped[float | None] = mapped_column(Float)
+    timeout_seconds: Mapped[float | None] = mapped_column(Float)
     created_at: Mapped[datetime] = mapped_column(
         DateTime, default=lambda: datetime.now(UTC), nullable=False, index=True
     )

--- a/ha_boss/notifications/manager.py
+++ b/ha_boss/notifications/manager.py
@@ -1,7 +1,7 @@
 """Notification manager for routing alerts to various channels."""
 
 import logging
-from enum import Enum
+from enum import StrEnum
 
 from ha_boss.core.config import Config
 from ha_boss.core.ha_client import HomeAssistantClient
@@ -14,7 +14,7 @@ from ha_boss.notifications.templates import (
 logger = logging.getLogger(__name__)
 
 
-class NotificationChannel(str, Enum):
+class NotificationChannel(StrEnum):
     """Notification delivery channels."""
 
     HOME_ASSISTANT = "home_assistant"  # HA persistent notifications

--- a/ha_boss/notifications/templates.py
+++ b/ha_boss/notifications/templates.py
@@ -2,11 +2,11 @@
 
 from dataclasses import dataclass
 from datetime import UTC, datetime
-from enum import Enum
+from enum import StrEnum
 from typing import Any
 
 
-class NotificationType(str, Enum):
+class NotificationType(StrEnum):
     """Types of notifications that can be sent."""
 
     HEALING_FAILURE = "healing_failure"
@@ -18,7 +18,7 @@ class NotificationType(str, Enum):
     ANOMALY_DETECTED = "anomaly_detected"
 
 
-class NotificationSeverity(str, Enum):
+class NotificationSeverity(StrEnum):
     """Severity levels for notifications."""
 
     INFO = "info"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,7 +100,6 @@ select = [
 ignore = [
     "E501", # line too long (handled by black)
     "B008", # function call in argument defaults (required for Typer)
-    "UP042", # str, Enum → StrEnum (requires Python 3.11+, deferred for now)
 ]
 
 [tool.mypy]

--- a/tests/api/test_healing_api.py
+++ b/tests/api/test_healing_api.py
@@ -391,10 +391,14 @@ def client(mock_service):
         with patch("ha_boss.api.app.get_service", return_value=mock_service):
             with patch("ha_boss.api.dependencies.get_service", return_value=mock_service):
                 with patch("ha_boss.api.routes.healing.get_service", return_value=mock_service):
-                    with patch("ha_boss.api.app.load_config") as mock_load_config:
-                        mock_load_config.return_value = mock_service.config
-                        app = create_app()
-                        yield TestClient(app)
+                    with patch(
+                        "ha_boss.api.routes.automations.get_service",
+                        return_value=mock_service,
+                    ):
+                        with patch("ha_boss.api.app.load_config") as mock_load_config:
+                            mock_load_config.return_value = mock_service.config
+                            app = create_app()
+                            yield TestClient(app)
 
 
 # ==================== GET /api/healing/cascade/{cascade_id} Tests ====================
@@ -601,7 +605,7 @@ def test_get_automation_health_no_executions(client, mock_service):
 
     assert data["total_executions"] == 0
     assert data["reliability_score"] == 0.0
-    assert data["last_execution_at"] is None
+    assert data["last_validation_at"] is None
 
 
 # ==================== POST /api/healing/cascade/{cascade_id}/retry Tests ====================


### PR DESCRIPTION
## Summary

Cleans up 10 open issues from Phase 2 cascade implementation, preparing for Phase 3 Healing Plan Framework (Epic #177).

### Issues Closed

| Issue | Title | Type |
|-------|-------|------|
| #202 | Integrate AutomationHealthTracker with outcome validation | API endpoint |
| #207 | Add timeout_seconds field to HealingCascadeExecution | DB model |
| #209 | Optimize database session usage in cascade orchestrator | New method |
| #210 | Enhance pattern learning with entity-specific matching | Query filter |
| #211 | Add test coverage for cascade orchestrator edge cases | 3 new tests |
| #212 | Add metrics for pattern coverage and intelligent routing | Metrics method + API |
| #215 | Document single-entity pattern learning limitation | CLAUDE.md docs |
| #216 | Migrate str,Enum classes to StrEnum (UP042) | 5 files migrated |
| #218 | Improve OutcomeValidator import organization | Import cleanup |
| #219 | Extract duplicate test helpers in cascade integration tests | Test refactor |

### Key Changes

- **New API endpoints**: `GET /automations/{id}/health` and `GET /healing/routing-metrics`
- **StrEnum migration**: All 5 `str, Enum` classes migrated, UP042 rule enabled
- **Pattern matching improvement**: Entity-specific filtering for better accuracy
- **DB optimization**: Batch update method for cascade level status
- **Test coverage**: 3 new edge case tests for cascade orchestrator
- **Documentation**: Healing architecture section added to CLAUDE.md

## Test plan

- [x] All 1131 tests pass (0 failures)
- [x] Black formatting clean
- [x] Ruff linting clean (UP042 now enabled)
- [x] mypy: 121 errors (same as baseline on main)
- [x] Pre-existing healing API tests now pass with new endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)