### PR TITLE
feat: Add plan matcher for healing context matching (Epic #177 Phase 3 PR3)

### DIFF
--- a/ha_boss/api/models.py
+++ b/ha_boss/api/models.py
@@ -1,7 +1,7 @@
 """Pydantic models for API requests and responses."""
 
 from datetime import datetime
-from enum import Enum
+from enum import StrEnum
 from typing import Any, Literal
 
 from pydantic import BaseModel, Field
@@ -470,7 +470,7 @@ class ConfigInstanceTestResponse(BaseModel):
 # Automation Desired States Models
 
 
-class InferenceMethod(str, Enum):
+class InferenceMethod(StrEnum):
     """Methods for inferring automation desired states."""
 
     AI_ANALYSIS = "ai_analysis"

--- a/ha_boss/api/routes/healing.py
+++ b/ha_boss/api/routes/healing.py
@@ -1114,3 +1114,36 @@ async def retry_failed_cascade(
     except Exception as e:
         logger.error(f"[{instance_id}] Error retrying cascade {cascade_id}: {e}", exc_info=True)
         raise HTTPException(status_code=500, detail="Failed to retry cascade") from None
+
+
+@router.get("/healing/routing-metrics")
+async def get_routing_metrics(
+    instance_id: str = Query("default", description="Instance identifier"),
+) -> dict[str, Any]:
+    """Get pattern coverage and routing effectiveness metrics.
+
+    Returns metrics about how well the intelligent routing and pattern
+    learning systems are performing.
+    """
+    try:
+        service = get_service()
+
+        if instance_id not in service.cascade_orchestrators:
+            raise HTTPException(
+                status_code=404,
+                detail=f"Instance '{instance_id}' not found or not initialized",
+            )
+
+        metrics = await service.cascade_orchestrators[instance_id].get_routing_metrics(
+            instance_id=instance_id,
+        )
+
+        return metrics
+
+    except HTTPException:
+        raise
+    except RuntimeError as e:
+        raise HTTPException(status_code=503, detail=str(e)) from None
+    except Exception as e:
+        logger.error(f"[{instance_id}] Error getting routing metrics: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail="Failed to get routing metrics") from None

--- a/ha_boss/automation/outcome_validator.py
+++ b/ha_boss/automation/outcome_validator.py
@@ -18,6 +18,7 @@ if TYPE_CHECKING:
     from ha_boss.healing.cascade_orchestrator import (
         CascadeOrchestrator,
         CascadeResult,
+        HealingContext,
     )
     from ha_boss.intelligence.llm_router import LLMRouter
 

--- a/ha_boss/core/config.py
+++ b/ha_boss/core/config.py
@@ -325,6 +325,20 @@ class HealingConfig(BaseSettings):
         description="Minimum ratio of entities that must recover for partial success (0.5 = 50%)",
     )
 
+    # Healing plans configuration
+    healing_plans_enabled: bool = Field(
+        default=True,
+        description="Enable YAML-based healing plans",
+    )
+    healing_plans_directory: str | None = Field(
+        default=None,
+        description="Directory for user-defined healing plan YAML files",
+    )
+    healing_plans_use_builtin: bool = Field(
+        default=True,
+        description="Load built-in healing plans",
+    )
+
 
 class NotificationsConfig(BaseSettings):
     """Notification configuration."""

--- a/ha_boss/core/config_service.py
+++ b/ha_boss/core/config_service.py
@@ -14,7 +14,7 @@ import json
 import logging
 import os
 from datetime import UTC, datetime
-from enum import Enum
+from enum import StrEnum
 from typing import Any
 
 from pydantic import BaseModel
@@ -28,7 +28,7 @@ from ha_boss.core.exceptions import ConfigServiceError
 logger = logging.getLogger(__name__)
 
 
-class ConfigSource(str, Enum):
+class ConfigSource(StrEnum):
     """Source of a configuration value."""
 
     DEFAULT = "default"

--- a/ha_boss/core/database.py
+++ b/ha_boss/core/database.py
@@ -866,6 +866,7 @@ class HealingCascadeExecution(Base):
     # Results
     final_success: Mapped[bool | None] = mapped_column(Boolean)
     total_duration_seconds: Mapped[float | None] = mapped_column(Float)
+    timeout_seconds: Mapped[float | None] = mapped_column(Float)
     created_at: Mapped[datetime] = mapped_column(
         DateTime, default=lambda: datetime.now(UTC), nullable=False, index=True
     )

--- a/ha_boss/core/exceptions.py
+++ b/ha_boss/core/exceptions.py
@@ -67,6 +67,30 @@ class CircuitBreakerOpenError(HealingError):
     pass
 
 
+class HealingPlanError(HealingError):
+    """Base exception for healing plan errors."""
+
+    pass
+
+
+class HealingPlanNotFoundError(HealingPlanError):
+    """Healing plan not found."""
+
+    pass
+
+
+class HealingPlanValidationError(HealingPlanError):
+    """Healing plan validation failed."""
+
+    pass
+
+
+class HealingPlanExecutionError(HealingPlanError):
+    """Healing plan execution failed."""
+
+    pass
+
+
 class DatabaseError(HABossError):
     """Database operation error."""
 

--- a/ha_boss/core/migrations/__init__.py
+++ b/ha_boss/core/migrations/__init__.py
@@ -155,6 +155,7 @@ def _load_migrations() -> None:
     from ha_boss.core.migrations.v6_add_healing_suppression import migrate_v5_to_v6
     from ha_boss.core.migrations.v7_add_outcome_validation import migrate_v6_to_v7
     from ha_boss.core.migrations.v8_multi_level_healing import migrate_v7_to_v8
+    from ha_boss.core.migrations.v9_add_healing_plans import migrate_v8_to_v9
 
     # Register all migrations with the registry
     MIGRATION_REGISTRY.register(
@@ -186,6 +187,11 @@ def _load_migrations() -> None:
         target_version=8,
         migrate_func=migrate_v7_to_v8,
         description="Add multi-level healing support",
+    )
+    MIGRATION_REGISTRY.register(
+        target_version=9,
+        migrate_func=migrate_v8_to_v9,
+        description="Add healing plan framework",
     )
 
 

--- a/ha_boss/core/migrations/v9_add_healing_plans.py
+++ b/ha_boss/core/migrations/v9_add_healing_plans.py
@@ -1,0 +1,126 @@
+"""Database migration: v8 → v9 - Add healing plan framework tables.
+
+This migration adds tables to support configurable YAML-based healing plans
+that augment the existing cascade orchestrator with user-defined strategies.
+
+Changes:
+- Add healing_plans table for plan definitions
+- Add healing_plan_executions table for execution tracking
+- Add timeout_seconds column to healing_cascade_executions (from Issue #207)
+"""
+
+import logging
+
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+logger = logging.getLogger(__name__)
+
+
+async def migrate_v8_to_v9(session: AsyncSession) -> None:
+    """Migrate database from v8 to v9.
+
+    Args:
+        session: Database session
+
+    Raises:
+        RuntimeError: If migration fails
+    """
+    logger.info("Starting migration from v8 to v9")
+
+    try:
+        connection = await session.connection()
+
+        # Create healing_plans table
+        await connection.execute(text("""
+            CREATE TABLE IF NOT EXISTS healing_plans (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                name VARCHAR(255) NOT NULL UNIQUE,
+                version INTEGER NOT NULL DEFAULT 1,
+                description TEXT,
+                enabled BOOLEAN NOT NULL DEFAULT 1,
+                priority INTEGER NOT NULL DEFAULT 0,
+                source VARCHAR(50) NOT NULL DEFAULT 'user',
+                match_criteria JSON,
+                steps JSON,
+                on_failure JSON,
+                tags JSON,
+                total_executions INTEGER NOT NULL DEFAULT 0,
+                total_successes INTEGER NOT NULL DEFAULT 0,
+                total_failures INTEGER NOT NULL DEFAULT 0,
+                created_at DATETIME NOT NULL,
+                updated_at DATETIME NOT NULL
+            )
+        """))
+        logger.info("Created healing_plans table")
+
+        # Create index on healing_plans name
+        await connection.execute(text("""
+            CREATE INDEX IF NOT EXISTS ix_healing_plans_name
+            ON healing_plans(name)
+        """))
+
+        # Create healing_plan_executions table
+        await connection.execute(text("""
+            CREATE TABLE IF NOT EXISTS healing_plan_executions (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                plan_id INTEGER NOT NULL,
+                plan_name VARCHAR(255) NOT NULL,
+                instance_id VARCHAR(255) NOT NULL,
+                automation_id VARCHAR(255),
+                cascade_execution_id INTEGER,
+                target_entities JSON,
+                steps_attempted JSON,
+                steps_succeeded INTEGER NOT NULL DEFAULT 0,
+                steps_failed INTEGER NOT NULL DEFAULT 0,
+                overall_success BOOLEAN,
+                total_duration_seconds REAL,
+                error_message TEXT,
+                created_at DATETIME NOT NULL,
+                completed_at DATETIME
+            )
+        """))
+        logger.info("Created healing_plan_executions table")
+
+        # Create indexes for healing_plan_executions
+        await connection.execute(text("""
+            CREATE INDEX IF NOT EXISTS ix_healing_plan_executions_plan_id
+            ON healing_plan_executions(plan_id)
+        """))
+        await connection.execute(text("""
+            CREATE INDEX IF NOT EXISTS ix_healing_plan_executions_instance_id
+            ON healing_plan_executions(instance_id)
+        """))
+        await connection.execute(text("""
+            CREATE INDEX IF NOT EXISTS ix_healing_plan_executions_created_at
+            ON healing_plan_executions(created_at)
+        """))
+        await connection.execute(text("""
+            CREATE INDEX IF NOT EXISTS idx_healing_plan_executions_plan_instance
+            ON healing_plan_executions(plan_id, instance_id)
+        """))
+
+        # Add timeout_seconds to healing_cascade_executions (Issue #207)
+        # Use try/except for idempotency (column may already exist on new installs)
+        try:
+            await connection.execute(
+                text("ALTER TABLE healing_cascade_executions ADD COLUMN timeout_seconds REAL")
+            )
+            logger.info("Added timeout_seconds column to healing_cascade_executions")
+        except Exception:
+            logger.debug("timeout_seconds column already exists, skipping")
+
+        # Update schema version
+        await connection.execute(
+            text(
+                "INSERT INTO schema_version (version, description, applied_at) VALUES (9, 'Add healing plan framework', datetime('now'))"
+            )
+        )
+        logger.info("Updated schema version to 9")
+
+        await session.commit()
+        logger.info("Migration v8 → v9 completed successfully")
+
+    except Exception as e:
+        logger.error(f"Migration v8 → v9 failed: {e}", exc_info=True)
+        raise RuntimeError(f"Migration v8 → v9 failed: {e}") from e

--- a/ha_boss/healing/plan_loader.py
+++ b/ha_boss/healing/plan_loader.py
@@ -1,0 +1,265 @@
+"""Load and validate YAML healing plans from filesystem and database.
+
+Plans are loaded from two sources:
+1. Built-in plans from ha_boss/healing/plans/ (source='builtin')
+2. User plans from the configured plans directory (source='user')
+3. Plans stored in the database via the API
+
+Plans are validated against the Pydantic schema and stored in the
+database for API access and execution stats tracking.
+"""
+
+import logging
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import yaml
+from pydantic import ValidationError
+from sqlalchemy import select
+
+from ha_boss.core.database import Database, HealingPlan
+from ha_boss.core.exceptions import HealingPlanNotFoundError, HealingPlanValidationError
+from ha_boss.healing.plan_models import HealingPlanDefinition
+
+logger = logging.getLogger(__name__)
+
+# Built-in plans directory
+BUILTIN_PLANS_DIR = Path(__file__).parent / "plans"
+
+
+class PlanLoader:
+    """Load and manage healing plans from YAML files and database.
+
+    Plans are loaded from the filesystem on startup and synced to the
+    database. The database copy is the runtime source of truth for
+    enabled/disabled state and execution statistics.
+    """
+
+    def __init__(
+        self,
+        database: Database,
+        user_plans_directory: str | None = None,
+        use_builtin: bool = True,
+    ) -> None:
+        """Initialize plan loader.
+
+        Args:
+            database: Database for storing/querying plans
+            user_plans_directory: Optional path to user-defined plans
+            use_builtin: Whether to load built-in plans (default: True)
+        """
+        self.database = database
+        self.user_plans_dir = Path(user_plans_directory) if user_plans_directory else None
+        self.use_builtin = use_builtin
+        self._plans: dict[str, HealingPlanDefinition] = {}
+
+    async def load_all_plans(self) -> list[HealingPlanDefinition]:
+        """Load all plans from filesystem and sync to database.
+
+        Returns:
+            List of validated plan definitions
+        """
+        plans: list[HealingPlanDefinition] = []
+        builtin_names: set[str] = set()
+
+        # Load built-in plans
+        if self.use_builtin and BUILTIN_PLANS_DIR.exists():
+            builtin_plans = self._load_plans_from_directory(BUILTIN_PLANS_DIR, source="builtin")
+            plans.extend(builtin_plans)
+            builtin_names = {p.name for p in builtin_plans}
+            logger.info(f"Loaded {len(builtin_plans)} built-in plans")
+
+        # Load user plans
+        if self.user_plans_dir and self.user_plans_dir.exists():
+            user_plans = self._load_plans_from_directory(self.user_plans_dir, source="user")
+            plans.extend(user_plans)
+            logger.info(f"Loaded {len(user_plans)} user plans")
+
+        # Sync to database
+        for plan in plans:
+            source = "builtin" if plan.name in builtin_names else "user"
+            await self._sync_plan_to_db(plan, source)
+
+        # Cache plans
+        self._plans = {plan.name: plan for plan in plans}
+
+        logger.info(f"Total plans loaded: {len(plans)}")
+        return plans
+
+    def _load_plans_from_directory(
+        self, directory: Path, source: str
+    ) -> list[HealingPlanDefinition]:
+        """Load and validate all YAML plans from a directory.
+
+        Args:
+            directory: Directory containing .yaml plan files
+            source: Plan source ('builtin' or 'user')
+
+        Returns:
+            List of validated plan definitions
+        """
+        plans: list[HealingPlanDefinition] = []
+
+        for yaml_file in sorted(directory.glob("*.yaml")):
+            try:
+                plan = self.load_plan_from_file(yaml_file)
+                plans.append(plan)
+                logger.debug(f"Loaded plan '{plan.name}' from {yaml_file} (source={source})")
+            except (HealingPlanValidationError, yaml.YAMLError) as e:
+                logger.error(f"Failed to load plan from {yaml_file}: {e}")
+            except Exception as e:
+                logger.error(f"Unexpected error loading {yaml_file}: {e}", exc_info=True)
+
+        return plans
+
+    @staticmethod
+    def load_plan_from_file(file_path: Path) -> HealingPlanDefinition:
+        """Load and validate a single YAML plan file.
+
+        Args:
+            file_path: Path to the YAML file
+
+        Returns:
+            Validated plan definition
+
+        Raises:
+            HealingPlanValidationError: If plan fails validation
+        """
+        try:
+            with open(file_path) as f:
+                data = yaml.safe_load(f)
+        except yaml.YAMLError as e:
+            raise HealingPlanValidationError(f"Invalid YAML in {file_path}: {e}") from e
+
+        if not isinstance(data, dict):
+            raise HealingPlanValidationError(f"Plan file {file_path} must contain a YAML mapping")
+
+        return PlanLoader.validate_plan_data(data)
+
+    @staticmethod
+    def validate_plan_data(data: dict[str, Any]) -> HealingPlanDefinition:
+        """Validate plan data against the Pydantic schema.
+
+        Args:
+            data: Raw plan data dict
+
+        Returns:
+            Validated plan definition
+
+        Raises:
+            HealingPlanValidationError: If validation fails
+        """
+        try:
+            return HealingPlanDefinition(**data)
+        except ValidationError as e:
+            raise HealingPlanValidationError(f"Plan validation failed: {e}") from e
+
+    async def _sync_plan_to_db(self, plan: HealingPlanDefinition, source: str) -> None:
+        """Sync a plan definition to the database.
+
+        Creates or updates the plan record. Preserves execution stats
+        and enabled/disabled state for existing plans.
+
+        Args:
+            plan: Validated plan definition
+            source: Plan source ('builtin' or 'user')
+        """
+        try:
+            async with self.database.async_session() as session:
+                result = await session.execute(
+                    select(HealingPlan).where(HealingPlan.name == plan.name)
+                )
+                existing = result.scalar_one_or_none()
+
+                if existing:
+                    # Update definition but preserve runtime state
+                    existing.version = plan.version
+                    existing.description = plan.description
+                    existing.priority = plan.priority
+                    existing.match_criteria = plan.match.model_dump()
+                    existing.steps = [s.model_dump() for s in plan.steps]
+                    existing.on_failure = plan.on_failure.model_dump()
+                    existing.tags = plan.tags
+                    existing.updated_at = datetime.now(UTC)
+                    # Don't overwrite enabled or execution stats
+                else:
+                    db_plan = HealingPlan(
+                        name=plan.name,
+                        version=plan.version,
+                        description=plan.description,
+                        enabled=plan.enabled,
+                        priority=plan.priority,
+                        source=source,
+                        match_criteria=plan.match.model_dump(),
+                        steps=[s.model_dump() for s in plan.steps],
+                        on_failure=plan.on_failure.model_dump(),
+                        tags=plan.tags,
+                        created_at=datetime.now(UTC),
+                        updated_at=datetime.now(UTC),
+                    )
+                    session.add(db_plan)
+
+                await session.commit()
+
+        except Exception as e:
+            logger.error(f"Failed to sync plan '{plan.name}' to database: {e}", exc_info=True)
+
+    async def get_plan(self, name: str) -> HealingPlanDefinition:
+        """Get a plan by name.
+
+        Args:
+            name: Plan name
+
+        Returns:
+            Plan definition
+
+        Raises:
+            HealingPlanNotFoundError: If plan not found
+        """
+        if name in self._plans:
+            return self._plans[name]
+
+        raise HealingPlanNotFoundError(f"Plan '{name}' not found")
+
+    async def get_all_enabled_plans(self) -> list[HealingPlanDefinition]:
+        """Get all enabled plans sorted by priority (highest first).
+
+        Returns:
+            List of enabled plan definitions sorted by priority
+        """
+        try:
+            async with self.database.async_session() as session:
+                result = await session.execute(
+                    select(HealingPlan)
+                    .where(HealingPlan.enabled == True)  # noqa: E712
+                    .order_by(HealingPlan.priority.desc())
+                )
+                db_plans = result.scalars().all()
+
+                plans = []
+                for db_plan in db_plans:
+                    try:
+                        plan = HealingPlanDefinition(
+                            name=db_plan.name,
+                            version=db_plan.version,
+                            description=db_plan.description or "",
+                            enabled=db_plan.enabled,
+                            priority=db_plan.priority,
+                            match=db_plan.match_criteria or {},
+                            steps=db_plan.steps or [],
+                            on_failure=db_plan.on_failure or {},
+                            tags=db_plan.tags or [],
+                        )
+                        plans.append(plan)
+                    except ValidationError as e:
+                        logger.error(
+                            f"Invalid plan '{db_plan.name}' in database: {e}",
+                            exc_info=True,
+                        )
+
+                return plans
+
+        except Exception as e:
+            logger.error(f"Failed to load enabled plans from database: {e}", exc_info=True)
+            return []

--- a/ha_boss/healing/plan_matcher.py
+++ b/ha_boss/healing/plan_matcher.py
@@ -1,0 +1,173 @@
+"""Match healing contexts to the best applicable healing plan.
+
+Uses fnmatch glob patterns for entity matching, consistent with the
+existing monitoring include/exclude patterns. Plans are evaluated in
+priority order (highest first), and the first matching plan wins.
+"""
+
+import logging
+from datetime import datetime
+from fnmatch import fnmatch
+
+from ha_boss.healing.cascade_orchestrator import HealingContext
+from ha_boss.healing.plan_loader import PlanLoader
+from ha_boss.healing.plan_models import HealingPlanDefinition, MatchCriteria
+
+logger = logging.getLogger(__name__)
+
+
+class PlanMatcher:
+    """Match healing contexts to applicable healing plans.
+
+    Evaluates enabled plans in priority order against the failure context.
+    A plan matches if ANY entity matches AND the failure type matches
+    (when criteria are specified).
+    """
+
+    def __init__(self, plan_loader: PlanLoader) -> None:
+        """Initialize plan matcher.
+
+        Args:
+            plan_loader: Loader providing access to plan definitions
+        """
+        self.plan_loader = plan_loader
+
+    async def find_matching_plan(
+        self,
+        context: HealingContext,
+        entity_integration_map: dict[str, str] | None = None,
+        failure_type: str = "unavailable",
+    ) -> HealingPlanDefinition | None:
+        """Find the best matching plan for a healing context.
+
+        Plans are evaluated in priority order (highest first).
+        Returns the first plan that matches all specified criteria.
+
+        Args:
+            context: Healing context with failed entities and metadata
+            entity_integration_map: Optional mapping of entity_id -> integration domain
+            failure_type: Type of failure (e.g., 'unavailable', 'unknown')
+
+        Returns:
+            Best matching plan or None if no plan matches
+        """
+        plans = await self.plan_loader.get_all_enabled_plans()
+
+        if not plans:
+            logger.debug("No enabled plans available")
+            return None
+
+        for plan in plans:
+            if self._plan_matches(plan, context, entity_integration_map, failure_type):
+                logger.info(
+                    f"Plan '{plan.name}' (priority={plan.priority}) matches "
+                    f"context for {context.automation_id} "
+                    f"({len(context.failed_entities)} entities)"
+                )
+                return plan
+
+        logger.debug(
+            f"No plan matched for {context.automation_id} " f"(checked {len(plans)} plans)"
+        )
+        return None
+
+    def _plan_matches(
+        self,
+        plan: HealingPlanDefinition,
+        context: HealingContext,
+        entity_integration_map: dict[str, str] | None,
+        failure_type: str,
+    ) -> bool:
+        """Check if a plan matches the given context.
+
+        A plan matches if ALL specified criteria are satisfied:
+        - entity_patterns: at least one failed entity matches a pattern
+        - integration_domains: at least one entity's integration matches
+        - failure_types: the failure type is in the list
+        - time_window: current hour is within the window
+
+        Args:
+            plan: Plan to check
+            context: Healing context
+            entity_integration_map: entity_id -> integration domain mapping
+            failure_type: Failure type string
+
+        Returns:
+            True if plan matches
+        """
+        match = plan.match
+
+        # Check failure types (if specified)
+        if match.failure_types and failure_type not in match.failure_types:
+            return False
+
+        # Check entity patterns (if specified)
+        if match.entity_patterns:
+            if not self._any_entity_matches_patterns(
+                context.failed_entities, match.entity_patterns
+            ):
+                return False
+
+        # Check integration domains (if specified)
+        if match.integration_domains and entity_integration_map:
+            if not self._any_entity_matches_integrations(
+                context.failed_entities,
+                match.integration_domains,
+                entity_integration_map,
+            ):
+                return False
+
+        # Check time window (if specified)
+        if match.time_window:
+            current_hour = datetime.now().hour
+            if not (match.time_window.start_hour <= current_hour < match.time_window.end_hour):
+                return False
+
+        return True
+
+    @staticmethod
+    def _any_entity_matches_patterns(entities: list[str], patterns: list[str]) -> bool:
+        """Check if any entity matches any of the glob patterns.
+
+        Args:
+            entities: List of entity IDs
+            patterns: List of fnmatch glob patterns
+
+        Returns:
+            True if at least one entity matches at least one pattern
+        """
+        return any(fnmatch(entity, pattern) for entity in entities for pattern in patterns)
+
+    @staticmethod
+    def _any_entity_matches_integrations(
+        entities: list[str],
+        domains: list[str],
+        entity_integration_map: dict[str, str],
+    ) -> bool:
+        """Check if any entity belongs to a matching integration domain.
+
+        Args:
+            entities: List of entity IDs
+            domains: List of integration domains
+            entity_integration_map: entity_id -> domain mapping
+
+        Returns:
+            True if at least one entity's integration matches
+        """
+        for entity in entities:
+            entity_domain = entity_integration_map.get(entity, "")
+            if entity_domain in domains:
+                return True
+        return False
+
+    @staticmethod
+    def match_criteria_to_dict(criteria: MatchCriteria) -> dict[str, object]:
+        """Convert match criteria to a dict for API responses.
+
+        Args:
+            criteria: Match criteria to convert
+
+        Returns:
+            Dictionary representation
+        """
+        return criteria.model_dump()

--- a/ha_boss/healing/plan_models.py
+++ b/ha_boss/healing/plan_models.py
@@ -1,0 +1,150 @@
+"""Pydantic models for YAML-based healing plan definitions.
+
+These models validate healing plan configurations loaded from YAML files
+or submitted via the API. Plans define match criteria and ordered healing
+steps that integrate with the cascade orchestrator.
+"""
+
+from pydantic import BaseModel, Field, field_validator
+
+
+class TimeWindow(BaseModel):
+    """Time window restriction for plan matching."""
+
+    start_hour: int = Field(default=0, ge=0, le=23)
+    end_hour: int = Field(default=24, ge=0, le=24)
+
+
+class MatchCriteria(BaseModel):
+    """Criteria for matching a healing plan to a failure.
+
+    Uses fnmatch glob patterns for entity matching, consistent with
+    the existing monitoring include/exclude patterns.
+    """
+
+    entity_patterns: list[str] = Field(
+        default_factory=list,
+        description="fnmatch glob patterns for entity IDs (e.g., 'light.zigbee_*')",
+    )
+    integration_domains: list[str] = Field(
+        default_factory=list,
+        description="Integration domains to match (e.g., 'zha', 'zigbee2mqtt')",
+    )
+    failure_types: list[str] = Field(
+        default_factory=list,
+        description="Failure types to match (e.g., 'unavailable', 'unknown')",
+    )
+    device_manufacturers: list[str] = Field(
+        default_factory=list,
+        description="Optional device manufacturer filter",
+    )
+    time_window: TimeWindow | None = Field(
+        default=None,
+        description="Optional time-of-day restriction",
+    )
+
+    @field_validator("entity_patterns", "integration_domains", "failure_types")
+    @classmethod
+    def at_least_one_criterion(cls, v: list[str], info: object) -> list[str]:
+        """Individual fields can be empty; overall match is checked at plan level."""
+        return v
+
+    def has_any_criteria(self) -> bool:
+        """Check if at least one matching criterion is defined."""
+        return bool(
+            self.entity_patterns
+            or self.integration_domains
+            or self.failure_types
+            or self.device_manufacturers
+        )
+
+
+class HealingStep(BaseModel):
+    """A single healing step within a plan."""
+
+    name: str = Field(..., description="Step identifier")
+    level: str = Field(
+        ...,
+        description="Healing level: 'entity', 'device', or 'integration'",
+    )
+    action: str = Field(
+        ...,
+        description="Healing action (e.g., 'retry_service_call', 'reconnect', 'reload_integration')",
+    )
+    params: dict[str, object] = Field(
+        default_factory=dict,
+        description="Action-specific parameters",
+    )
+    timeout_seconds: float = Field(
+        default=30.0,
+        ge=1.0,
+        le=600.0,
+        description="Timeout for this step",
+    )
+
+    @field_validator("level")
+    @classmethod
+    def validate_level(cls, v: str) -> str:
+        """Validate healing level is one of the known levels."""
+        valid_levels = {"entity", "device", "integration"}
+        if v not in valid_levels:
+            raise ValueError(f"Invalid level '{v}', must be one of: {valid_levels}")
+        return v
+
+
+class OnFailureConfig(BaseModel):
+    """Configuration for what happens when all plan steps fail."""
+
+    escalate: bool = Field(default=True, description="Escalate to notifications")
+    cooldown_seconds: int = Field(
+        default=600,
+        ge=0,
+        description="Cooldown before this plan can be tried again",
+    )
+
+
+class HealingPlanDefinition(BaseModel):
+    """Complete healing plan definition matching the YAML schema.
+
+    This is the top-level model that validates a complete healing plan,
+    whether loaded from a YAML file or submitted via the API.
+    """
+
+    name: str = Field(..., description="Unique plan identifier")
+    version: int = Field(default=1, ge=1, description="Plan version")
+    description: str = Field(default="", description="Human-readable description")
+    enabled: bool = Field(default=True, description="Whether the plan is active")
+    priority: int = Field(
+        default=0,
+        ge=0,
+        description="Higher priority plans are evaluated first",
+    )
+
+    match: MatchCriteria = Field(
+        ...,
+        description="Criteria for matching failures to this plan",
+    )
+    steps: list[HealingStep] = Field(
+        ...,
+        min_length=1,
+        description="Ordered list of healing steps to execute",
+    )
+    on_failure: OnFailureConfig = Field(
+        default_factory=OnFailureConfig,
+        description="What to do when all steps fail",
+    )
+    tags: list[str] = Field(
+        default_factory=list,
+        description="Tags for filtering and categorization",
+    )
+
+    @field_validator("match")
+    @classmethod
+    def validate_match_has_criteria(cls, v: MatchCriteria) -> MatchCriteria:
+        """Ensure at least one matching criterion is defined."""
+        if not v.has_any_criteria():
+            raise ValueError(
+                "Match criteria must have at least one of: "
+                "entity_patterns, integration_domains, failure_types, device_manufacturers"
+            )
+        return v

--- a/ha_boss/notifications/manager.py
+++ b/ha_boss/notifications/manager.py
@@ -1,7 +1,7 @@
 """Notification manager for routing alerts to various channels."""
 
 import logging
-from enum import Enum
+from enum import StrEnum
 
 from ha_boss.core.config import Config
 from ha_boss.core.ha_client import HomeAssistantClient
@@ -14,7 +14,7 @@ from ha_boss.notifications.templates import (
 logger = logging.getLogger(__name__)
 
 
-class NotificationChannel(str, Enum):
+class NotificationChannel(StrEnum):
     """Notification delivery channels."""
 
     HOME_ASSISTANT = "home_assistant"  # HA persistent notifications

--- a/ha_boss/notifications/templates.py
+++ b/ha_boss/notifications/templates.py
@@ -2,11 +2,11 @@
 
 from dataclasses import dataclass
 from datetime import UTC, datetime
-from enum import Enum
+from enum import StrEnum
 from typing import Any
 
 
-class NotificationType(str, Enum):
+class NotificationType(StrEnum):
     """Types of notifications that can be sent."""
 
     HEALING_FAILURE = "healing_failure"
@@ -18,7 +18,7 @@ class NotificationType(str, Enum):
     ANOMALY_DETECTED = "anomaly_detected"
 
 
-class NotificationSeverity(str, Enum):
+class NotificationSeverity(StrEnum):
     """Severity levels for notifications."""
 
     INFO = "info"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,7 +100,6 @@ select = [
 ignore = [
     "E501", # line too long (handled by black)
     "B008", # function call in argument defaults (required for Typer)
-    "UP042", # str, Enum → StrEnum (requires Python 3.11+, deferred for now)
 ]
 
 [tool.mypy]

--- a/tests/api/test_healing_api.py
+++ b/tests/api/test_healing_api.py
@@ -391,10 +391,14 @@ def client(mock_service):
         with patch("ha_boss.api.app.get_service", return_value=mock_service):
             with patch("ha_boss.api.dependencies.get_service", return_value=mock_service):
                 with patch("ha_boss.api.routes.healing.get_service", return_value=mock_service):
-                    with patch("ha_boss.api.app.load_config") as mock_load_config:
-                        mock_load_config.return_value = mock_service.config
-                        app = create_app()
-                        yield TestClient(app)
+                    with patch(
+                        "ha_boss.api.routes.automations.get_service",
+                        return_value=mock_service,
+                    ):
+                        with patch("ha_boss.api.app.load_config") as mock_load_config:
+                            mock_load_config.return_value = mock_service.config
+                            app = create_app()
+                            yield TestClient(app)
 
 
 # ==================== GET /api/healing/cascade/{cascade_id} Tests ====================
@@ -601,7 +605,7 @@ def test_get_automation_health_no_executions(client, mock_service):
 
     assert data["total_executions"] == 0
     assert data["reliability_score"] == 0.0
-    assert data["last_execution_at"] is None
+    assert data["last_validation_at"] is None
 
 
 # ==================== POST /api/healing/cascade/{cascade_id}/retry Tests ====================

--- a/tests/healing/test_plan_loader.py
+++ b/tests/healing/test_plan_loader.py
@@ -1,0 +1,229 @@
+"""Tests for healing plan YAML loader."""
+
+import pytest
+import yaml
+
+from ha_boss.core.database import HealingPlan, init_database
+from ha_boss.core.exceptions import HealingPlanNotFoundError, HealingPlanValidationError
+from ha_boss.healing.plan_loader import PlanLoader
+
+
+@pytest.fixture
+async def database(tmp_path):
+    """Create a test database."""
+    db = await init_database(str(tmp_path / "test.db"))
+    yield db
+    await db.engine.dispose()
+
+
+@pytest.fixture
+def sample_plan_yaml(tmp_path):
+    """Create a sample YAML plan file."""
+    plan_data = {
+        "name": "test_zigbee",
+        "version": 1,
+        "description": "Test zigbee plan",
+        "enabled": True,
+        "priority": 10,
+        "match": {
+            "entity_patterns": ["light.zigbee_*"],
+            "integration_domains": ["zha"],
+            "failure_types": ["unavailable"],
+        },
+        "steps": [
+            {
+                "name": "retry",
+                "level": "entity",
+                "action": "retry_service_call",
+                "timeout_seconds": 15,
+            },
+            {
+                "name": "reconnect",
+                "level": "device",
+                "action": "reconnect",
+                "timeout_seconds": 20,
+            },
+        ],
+        "on_failure": {"escalate": True, "cooldown_seconds": 600},
+        "tags": ["zigbee", "connectivity"],
+    }
+
+    plan_file = tmp_path / "test_zigbee.yaml"
+    with open(plan_file, "w") as f:
+        yaml.dump(plan_data, f)
+
+    return plan_file
+
+
+@pytest.fixture
+def plans_directory(tmp_path, sample_plan_yaml):
+    """Create a directory with plan files."""
+    plans_dir = tmp_path / "plans"
+    plans_dir.mkdir()
+
+    # Copy sample plan to plans directory
+    import shutil
+
+    shutil.copy(sample_plan_yaml, plans_dir / "test_zigbee.yaml")
+
+    # Add a second plan
+    plan2 = {
+        "name": "test_wifi",
+        "version": 1,
+        "match": {
+            "integration_domains": ["tuya"],
+            "failure_types": ["unavailable"],
+        },
+        "steps": [
+            {
+                "name": "reload",
+                "level": "integration",
+                "action": "reload_integration",
+                "timeout_seconds": 30,
+            },
+        ],
+    }
+    with open(plans_dir / "test_wifi.yaml", "w") as f:
+        yaml.dump(plan2, f)
+
+    return plans_dir
+
+
+class TestPlanLoaderFile:
+    """Test loading plans from files."""
+
+    def test_load_plan_from_file(self, sample_plan_yaml):
+        """Test loading a single plan from YAML file."""
+        plan = PlanLoader.load_plan_from_file(sample_plan_yaml)
+        assert plan.name == "test_zigbee"
+        assert plan.priority == 10
+        assert len(plan.steps) == 2
+        assert plan.tags == ["zigbee", "connectivity"]
+
+    def test_load_invalid_yaml(self, tmp_path):
+        """Test loading invalid YAML raises error."""
+        bad_file = tmp_path / "bad.yaml"
+        bad_file.write_text("{{invalid yaml")
+        with pytest.raises(HealingPlanValidationError, match="Invalid YAML"):
+            PlanLoader.load_plan_from_file(bad_file)
+
+    def test_load_non_dict_yaml(self, tmp_path):
+        """Test loading non-dict YAML raises error."""
+        bad_file = tmp_path / "list.yaml"
+        bad_file.write_text("- item1\n- item2\n")
+        with pytest.raises(HealingPlanValidationError, match="must contain a YAML mapping"):
+            PlanLoader.load_plan_from_file(bad_file)
+
+    def test_load_missing_required_fields(self, tmp_path):
+        """Test loading plan with missing fields raises error."""
+        bad_file = tmp_path / "incomplete.yaml"
+        with open(bad_file, "w") as f:
+            yaml.dump({"name": "incomplete"}, f)
+        with pytest.raises(HealingPlanValidationError, match="validation failed"):
+            PlanLoader.load_plan_from_file(bad_file)
+
+
+class TestPlanLoaderValidation:
+    """Test plan data validation."""
+
+    def test_validate_valid_data(self):
+        data = {
+            "name": "test",
+            "match": {"failure_types": ["unavailable"]},
+            "steps": [{"name": "retry", "level": "entity", "action": "retry"}],
+        }
+        plan = PlanLoader.validate_plan_data(data)
+        assert plan.name == "test"
+
+    def test_validate_invalid_data(self):
+        with pytest.raises(HealingPlanValidationError):
+            PlanLoader.validate_plan_data({"name": "bad"})
+
+
+class TestPlanLoaderDatabase:
+    """Test plan loading with database sync."""
+
+    @pytest.mark.asyncio
+    async def test_load_from_directory(self, database, plans_directory):
+        """Test loading plans from a directory and syncing to DB."""
+        loader = PlanLoader(
+            database=database,
+            user_plans_directory=str(plans_directory),
+            use_builtin=False,
+        )
+        plans = await loader.load_all_plans()
+        assert len(plans) >= 2
+
+        # Check they're synced to database
+        async with database.async_session() as session:
+            result = await session.execute(__import__("sqlalchemy").select(HealingPlan))
+            db_plans = result.scalars().all()
+            assert len(db_plans) >= 2
+
+    @pytest.mark.asyncio
+    async def test_get_plan(self, database, plans_directory):
+        """Test getting a loaded plan by name."""
+        loader = PlanLoader(
+            database=database,
+            user_plans_directory=str(plans_directory),
+            use_builtin=False,
+        )
+        await loader.load_all_plans()
+        plan = await loader.get_plan("test_zigbee")
+        assert plan.name == "test_zigbee"
+
+    @pytest.mark.asyncio
+    async def test_get_plan_not_found(self, database):
+        """Test getting a non-existent plan raises error."""
+        loader = PlanLoader(database=database, use_builtin=False)
+        with pytest.raises(HealingPlanNotFoundError):
+            await loader.get_plan("nonexistent")
+
+    @pytest.mark.asyncio
+    async def test_get_all_enabled_plans(self, database, plans_directory):
+        """Test getting all enabled plans sorted by priority."""
+        loader = PlanLoader(
+            database=database,
+            user_plans_directory=str(plans_directory),
+            use_builtin=False,
+        )
+        await loader.load_all_plans()
+        enabled = await loader.get_all_enabled_plans()
+        assert len(enabled) >= 2
+        # Should be sorted by priority descending
+        if len(enabled) >= 2:
+            assert enabled[0].priority >= enabled[1].priority
+
+    @pytest.mark.asyncio
+    async def test_sync_preserves_enabled_state(self, database, plans_directory):
+        """Test that re-syncing plans preserves enabled/disabled state."""
+        loader = PlanLoader(
+            database=database,
+            user_plans_directory=str(plans_directory),
+            use_builtin=False,
+        )
+        await loader.load_all_plans()
+
+        # Disable a plan in the DB
+        async with database.async_session() as session:
+            result = await session.execute(
+                __import__("sqlalchemy")
+                .select(HealingPlan)
+                .where(HealingPlan.name == "test_zigbee")
+            )
+            plan = result.scalar_one()
+            plan.enabled = False
+            await session.commit()
+
+        # Reload plans
+        await loader.load_all_plans()
+
+        # Check enabled state was preserved
+        async with database.async_session() as session:
+            result = await session.execute(
+                __import__("sqlalchemy")
+                .select(HealingPlan)
+                .where(HealingPlan.name == "test_zigbee")
+            )
+            plan = result.scalar_one()
+            assert plan.enabled is False

--- a/tests/healing/test_plan_matcher.py
+++ b/tests/healing/test_plan_matcher.py
@@ -1,0 +1,354 @@
+"""Tests for healing plan matcher."""
+
+from datetime import datetime
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+
+from ha_boss.healing.cascade_orchestrator import HealingContext
+from ha_boss.healing.plan_loader import PlanLoader
+from ha_boss.healing.plan_matcher import PlanMatcher
+from ha_boss.healing.plan_models import (
+    HealingPlanDefinition,
+    HealingStep,
+    MatchCriteria,
+    OnFailureConfig,
+    TimeWindow,
+)
+
+
+def _make_plan(
+    name: str,
+    priority: int = 0,
+    entity_patterns: list[str] | None = None,
+    integration_domains: list[str] | None = None,
+    failure_types: list[str] | None = None,
+    time_window: TimeWindow | None = None,
+    enabled: bool = True,
+) -> HealingPlanDefinition:
+    """Create a healing plan with default step.
+
+    If no criteria are specified, defaults to failure_types=["unavailable"]
+    to satisfy the MatchCriteria validator requiring at least one criterion.
+    """
+    ep = entity_patterns or []
+    ids = integration_domains or []
+    ft = failure_types if failure_types is not None else []
+    # Ensure at least one criterion exists for Pydantic validation
+    if not ep and not ids and not ft:
+        ft = ["unavailable"]
+    match_criteria = MatchCriteria(
+        entity_patterns=ep,
+        integration_domains=ids,
+        failure_types=ft,
+        time_window=time_window,
+    )
+
+    return HealingPlanDefinition(
+        name=name,
+        priority=priority,
+        enabled=enabled,
+        match=match_criteria,
+        steps=[
+            HealingStep(
+                name="reload",
+                level="integration",
+                action="reload_integration",
+            )
+        ],
+        on_failure=OnFailureConfig(),
+    )
+
+
+def _make_context(
+    entities: list[str],
+    automation_id: str = "test_auto",
+    instance_id: str = "test_instance",
+) -> HealingContext:
+    """Create a healing context."""
+    return HealingContext(
+        automation_id=automation_id,
+        instance_id=instance_id,
+        execution_id=None,
+        trigger_type="trigger_failure",
+        failed_entities=entities,
+    )
+
+
+def _make_matcher(plans: list[HealingPlanDefinition]) -> PlanMatcher:
+    """Create a plan matcher with mocked plan loader."""
+    mock_loader = Mock(spec=PlanLoader)
+    mock_loader.get_all_enabled_plans = AsyncMock(return_value=plans)
+    return PlanMatcher(plan_loader=mock_loader)
+
+
+class TestEntityPatternMatching:
+    @pytest.mark.asyncio
+    async def test_exact_entity_match(self) -> None:
+        plan = _make_plan("test", entity_patterns=["light.bedroom"])
+        matcher = _make_matcher([plan])
+        context = _make_context(["light.bedroom"])
+
+        result = await matcher.find_matching_plan(context)
+
+        assert result == plan
+
+    @pytest.mark.asyncio
+    async def test_glob_pattern_match(self) -> None:
+        plan = _make_plan("test", entity_patterns=["light.zigbee_*"])
+        matcher = _make_matcher([plan])
+        context = _make_context(["light.zigbee_lamp_1", "light.zigbee_lamp_2"])
+
+        result = await matcher.find_matching_plan(context)
+
+        assert result == plan
+
+    @pytest.mark.asyncio
+    async def test_no_pattern_match(self) -> None:
+        plan = _make_plan("test", entity_patterns=["light.bedroom"])
+        matcher = _make_matcher([plan])
+        context = _make_context(["light.kitchen"])
+
+        result = await matcher.find_matching_plan(context)
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_multiple_patterns_any_match(self) -> None:
+        plan = _make_plan(
+            "test",
+            entity_patterns=["light.bedroom", "switch.garage"],
+        )
+        matcher = _make_matcher([plan])
+        context = _make_context(["switch.garage", "light.kitchen"])
+
+        result = await matcher.find_matching_plan(context)
+
+        assert result == plan
+
+    @pytest.mark.asyncio
+    async def test_multiple_entities_any_match(self) -> None:
+        plan = _make_plan("test", entity_patterns=["light.bedroom"])
+        matcher = _make_matcher([plan])
+        context = _make_context(["light.kitchen", "light.bedroom", "switch.garage"])
+
+        result = await matcher.find_matching_plan(context)
+
+        assert result == plan
+
+
+class TestIntegrationDomainMatching:
+    @pytest.mark.asyncio
+    async def test_entity_matches_domain(self) -> None:
+        plan = _make_plan("test", integration_domains=["zigbee2mqtt"])
+        matcher = _make_matcher([plan])
+        context = _make_context(["light.bedroom"])
+        entity_map = {"light.bedroom": "zigbee2mqtt"}
+
+        result = await matcher.find_matching_plan(context, entity_integration_map=entity_map)
+
+        assert result == plan
+
+    @pytest.mark.asyncio
+    async def test_entity_no_domain_match(self) -> None:
+        plan = _make_plan("test", integration_domains=["zigbee2mqtt"])
+        matcher = _make_matcher([plan])
+        context = _make_context(["light.bedroom"])
+        entity_map = {"light.bedroom": "zwave"}
+
+        result = await matcher.find_matching_plan(context, entity_integration_map=entity_map)
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_no_integration_map_skips_check(self) -> None:
+        plan = _make_plan("test", integration_domains=["zigbee2mqtt"])
+        matcher = _make_matcher([plan])
+        context = _make_context(["light.bedroom"])
+
+        result = await matcher.find_matching_plan(context, entity_integration_map=None)
+
+        assert result == plan
+
+    @pytest.mark.asyncio
+    async def test_entity_not_in_map(self) -> None:
+        plan = _make_plan("test", integration_domains=["zigbee2mqtt"])
+        matcher = _make_matcher([plan])
+        context = _make_context(["light.bedroom", "light.kitchen"])
+        entity_map = {"light.bedroom": "zwave"}
+
+        result = await matcher.find_matching_plan(context, entity_integration_map=entity_map)
+
+        assert result is None
+
+
+class TestFailureTypeMatching:
+    @pytest.mark.asyncio
+    async def test_matching_failure_type(self) -> None:
+        plan = _make_plan("test", failure_types=["unavailable"])
+        matcher = _make_matcher([plan])
+        context = _make_context(["light.bedroom"])
+
+        result = await matcher.find_matching_plan(context, failure_type="unavailable")
+
+        assert result == plan
+
+    @pytest.mark.asyncio
+    async def test_non_matching_failure_type(self) -> None:
+        plan = _make_plan("test", failure_types=["unavailable"])
+        matcher = _make_matcher([plan])
+        context = _make_context(["light.bedroom"])
+
+        result = await matcher.find_matching_plan(context, failure_type="timeout")
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_no_failure_types_matches_all(self) -> None:
+        plan = _make_plan("test", entity_patterns=["light.*"], failure_types=[])
+        matcher = _make_matcher([plan])
+        context = _make_context(["light.bedroom"])
+
+        result = await matcher.find_matching_plan(context, failure_type="timeout")
+
+        assert result == plan
+
+
+class TestTimeWindowMatching:
+    @pytest.mark.asyncio
+    async def test_within_time_window(self) -> None:
+        plan = _make_plan("test", time_window=TimeWindow(start_hour=8, end_hour=18))
+        matcher = _make_matcher([plan])
+        context = _make_context(["light.bedroom"])
+
+        with patch("ha_boss.healing.plan_matcher.datetime") as mock_dt:
+            mock_dt.now.return_value = datetime(2024, 1, 1, 12, 0)
+            result = await matcher.find_matching_plan(context)
+
+        assert result == plan
+
+    @pytest.mark.asyncio
+    async def test_outside_time_window(self) -> None:
+        plan = _make_plan("test", time_window=TimeWindow(start_hour=8, end_hour=18))
+        matcher = _make_matcher([plan])
+        context = _make_context(["light.bedroom"])
+
+        with patch("ha_boss.healing.plan_matcher.datetime") as mock_dt:
+            mock_dt.now.return_value = datetime(2024, 1, 1, 20, 0)
+            result = await matcher.find_matching_plan(context)
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_no_time_window_matches_all(self) -> None:
+        plan = _make_plan("test", time_window=None)
+        matcher = _make_matcher([plan])
+        context = _make_context(["light.bedroom"])
+
+        with patch("ha_boss.healing.plan_matcher.datetime") as mock_dt:
+            mock_dt.now.return_value = datetime(2024, 1, 1, 3, 0)
+            result = await matcher.find_matching_plan(context)
+
+        assert result == plan
+
+
+class TestPlanMatcherFindPlan:
+    @pytest.mark.asyncio
+    async def test_no_enabled_plans_returns_none(self) -> None:
+        matcher = _make_matcher([])
+        context = _make_context(["light.bedroom"])
+
+        result = await matcher.find_matching_plan(context)
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_single_matching_plan(self) -> None:
+        plan = _make_plan("test", entity_patterns=["light.*"])
+        matcher = _make_matcher([plan])
+        context = _make_context(["light.bedroom"])
+
+        result = await matcher.find_matching_plan(context)
+
+        assert result == plan
+
+    @pytest.mark.asyncio
+    async def test_priority_ordering(self) -> None:
+        low_priority = _make_plan("low", priority=10, entity_patterns=["light.*"])
+        high_priority = _make_plan("high", priority=100, entity_patterns=["light.*"])
+        matcher = _make_matcher([high_priority, low_priority])
+        context = _make_context(["light.bedroom"])
+
+        result = await matcher.find_matching_plan(context)
+
+        assert result == high_priority
+
+    @pytest.mark.asyncio
+    async def test_no_matching_plan_returns_none(self) -> None:
+        plan1 = _make_plan("test1", entity_patterns=["switch.*"])
+        plan2 = _make_plan("test2", failure_types=["timeout"])
+        matcher = _make_matcher([plan1, plan2])
+        context = _make_context(["light.bedroom"])
+
+        result = await matcher.find_matching_plan(context, failure_type="unavailable")
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_multiple_criteria_all_must_match(self) -> None:
+        plan = _make_plan(
+            "test",
+            entity_patterns=["light.*"],
+            failure_types=["unavailable"],
+            integration_domains=["zigbee2mqtt"],
+        )
+        matcher = _make_matcher([plan])
+        context = _make_context(["light.bedroom"])
+        entity_map = {"light.bedroom": "zigbee2mqtt"}
+
+        result = await matcher.find_matching_plan(
+            context,
+            entity_integration_map=entity_map,
+            failure_type="unavailable",
+        )
+
+        assert result == plan
+
+    @pytest.mark.asyncio
+    async def test_multiple_criteria_any_fails_no_match(self) -> None:
+        plan = _make_plan(
+            "test",
+            entity_patterns=["light.*"],
+            failure_types=["unavailable"],
+            integration_domains=["zigbee2mqtt"],
+        )
+        matcher = _make_matcher([plan])
+        context = _make_context(["light.bedroom"])
+        entity_map = {"light.bedroom": "zwave"}
+
+        result = await matcher.find_matching_plan(
+            context,
+            entity_integration_map=entity_map,
+            failure_type="unavailable",
+        )
+
+        assert result is None
+
+
+class TestMatchCriteriaToDict:
+    def test_converts_to_dict(self) -> None:
+        criteria = MatchCriteria(
+            entity_patterns=["light.*"],
+            integration_domains=["zigbee2mqtt"],
+            failure_types=["unavailable"],
+            time_window=TimeWindow(start_hour=8, end_hour=18),
+        )
+
+        result = PlanMatcher.match_criteria_to_dict(criteria)
+
+        assert isinstance(result, dict)
+        assert result["entity_patterns"] == ["light.*"]
+        assert result["integration_domains"] == ["zigbee2mqtt"]
+        assert result["failure_types"] == ["unavailable"]
+        assert result["time_window"] == {"start_hour": 8, "end_hour": 18}
+        assert result["device_manufacturers"] == []

--- a/tests/healing/test_plan_models.py
+++ b/tests/healing/test_plan_models.py
@@ -1,0 +1,187 @@
+"""Tests for healing plan Pydantic models."""
+
+import pytest
+from pydantic import ValidationError
+
+from ha_boss.healing.plan_models import (
+    HealingPlanDefinition,
+    HealingStep,
+    MatchCriteria,
+    OnFailureConfig,
+    TimeWindow,
+)
+
+
+class TestTimeWindow:
+    """Tests for TimeWindow model."""
+
+    def test_default_values(self):
+        tw = TimeWindow()
+        assert tw.start_hour == 0
+        assert tw.end_hour == 24
+
+    def test_custom_values(self):
+        tw = TimeWindow(start_hour=8, end_hour=20)
+        assert tw.start_hour == 8
+        assert tw.end_hour == 20
+
+    def test_invalid_hour(self):
+        with pytest.raises(ValidationError):
+            TimeWindow(start_hour=25)
+
+
+class TestMatchCriteria:
+    """Tests for MatchCriteria model."""
+
+    def test_entity_patterns(self):
+        mc = MatchCriteria(entity_patterns=["light.zigbee_*"])
+        assert mc.has_any_criteria()
+
+    def test_integration_domains(self):
+        mc = MatchCriteria(integration_domains=["zha"])
+        assert mc.has_any_criteria()
+
+    def test_failure_types(self):
+        mc = MatchCriteria(failure_types=["unavailable"])
+        assert mc.has_any_criteria()
+
+    def test_no_criteria(self):
+        mc = MatchCriteria()
+        assert not mc.has_any_criteria()
+
+    def test_multiple_criteria(self):
+        mc = MatchCriteria(
+            entity_patterns=["light.*"],
+            integration_domains=["zha"],
+            failure_types=["unavailable", "unknown"],
+        )
+        assert mc.has_any_criteria()
+
+
+class TestHealingStep:
+    """Tests for HealingStep model."""
+
+    def test_valid_step(self):
+        step = HealingStep(
+            name="retry",
+            level="entity",
+            action="retry_service_call",
+        )
+        assert step.name == "retry"
+        assert step.level == "entity"
+        assert step.timeout_seconds == 30.0
+
+    def test_all_levels(self):
+        for level in ["entity", "device", "integration"]:
+            step = HealingStep(name="test", level=level, action="test")
+            assert step.level == level
+
+    def test_invalid_level(self):
+        with pytest.raises(ValidationError, match="Invalid level"):
+            HealingStep(name="test", level="invalid", action="test")
+
+    def test_custom_params(self):
+        step = HealingStep(
+            name="retry",
+            level="entity",
+            action="retry_service_call",
+            params={"max_attempts": 3, "base_delay_seconds": 1.0},
+            timeout_seconds=15.0,
+        )
+        assert step.params["max_attempts"] == 3
+        assert step.timeout_seconds == 15.0
+
+
+class TestOnFailureConfig:
+    """Tests for OnFailureConfig model."""
+
+    def test_defaults(self):
+        ofc = OnFailureConfig()
+        assert ofc.escalate is True
+        assert ofc.cooldown_seconds == 600
+
+    def test_custom(self):
+        ofc = OnFailureConfig(escalate=False, cooldown_seconds=300)
+        assert ofc.escalate is False
+        assert ofc.cooldown_seconds == 300
+
+
+class TestHealingPlanDefinition:
+    """Tests for HealingPlanDefinition model."""
+
+    def test_valid_plan(self):
+        plan = HealingPlanDefinition(
+            name="zigbee_offline",
+            description="Fix zigbee devices",
+            priority=10,
+            match=MatchCriteria(
+                entity_patterns=["light.zigbee_*"],
+                integration_domains=["zha"],
+                failure_types=["unavailable"],
+            ),
+            steps=[
+                HealingStep(name="retry", level="entity", action="retry_service_call"),
+                HealingStep(name="reconnect", level="device", action="reconnect"),
+            ],
+            tags=["zigbee"],
+        )
+        assert plan.name == "zigbee_offline"
+        assert len(plan.steps) == 2
+        assert plan.enabled is True
+        assert plan.version == 1
+
+    def test_minimal_plan(self):
+        plan = HealingPlanDefinition(
+            name="minimal",
+            match=MatchCriteria(failure_types=["unavailable"]),
+            steps=[HealingStep(name="reload", level="integration", action="reload_integration")],
+        )
+        assert plan.name == "minimal"
+        assert plan.description == ""
+        assert plan.priority == 0
+
+    def test_no_match_criteria_fails(self):
+        with pytest.raises(ValidationError, match="at least one"):
+            HealingPlanDefinition(
+                name="bad",
+                match=MatchCriteria(),
+                steps=[HealingStep(name="test", level="entity", action="test")],
+            )
+
+    def test_no_steps_fails(self):
+        with pytest.raises(ValidationError):
+            HealingPlanDefinition(
+                name="bad",
+                match=MatchCriteria(failure_types=["unavailable"]),
+                steps=[],
+            )
+
+    def test_plan_from_dict(self):
+        """Test creating plan from dict (simulates YAML loading)."""
+        data = {
+            "name": "test_plan",
+            "version": 1,
+            "description": "A test plan",
+            "enabled": True,
+            "priority": 5,
+            "match": {
+                "entity_patterns": ["sensor.*"],
+                "failure_types": ["unavailable"],
+            },
+            "steps": [
+                {
+                    "name": "retry",
+                    "level": "entity",
+                    "action": "retry_service_call",
+                    "params": {"max_attempts": 3},
+                    "timeout_seconds": 15,
+                },
+            ],
+            "on_failure": {"escalate": True, "cooldown_seconds": 300},
+            "tags": ["test"],
+        }
+        plan = HealingPlanDefinition(**data)
+        assert plan.name == "test_plan"
+        assert plan.priority == 5
+        assert plan.steps[0].params["max_attempts"] == 3
+        assert plan.on_failure.cooldown_seconds == 300


### PR DESCRIPTION
## Summary
- Implements `PlanMatcher` class that matches `HealingContext` to the best applicable healing plan
- Uses fnmatch glob patterns for entity matching, consistent with existing monitoring patterns
- Plans evaluated in priority order (highest first), first match wins
- Supports entity pattern, integration domain, failure type, and time window criteria

## Changes
- `ha_boss/healing/plan_matcher.py` — New PlanMatcher class with `find_matching_plan()` async method
- `tests/healing/test_plan_matcher.py` — 22 tests covering all matching criteria, priority ordering, and edge cases

## Test plan
- [x] All 22 new plan matcher tests pass
- [x] Full test suite: 1183 passed, 11 skipped
- [x] Black formatting passes
- [x] Ruff linting passes

Part of Epic #177 Phase 3: Healing Plan Framework (PR 3 of 8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)