### PR TITLE
feat: Add plan executor for step-by-step plan healing (Epic #177 Phase 3 PR4)

### DIFF
--- a/ha_boss/healing/plan_executor.py
+++ b/ha_boss/healing/plan_executor.py
@@ -1,0 +1,338 @@
+"""Execute healing plans using existing healer infrastructure.
+
+Runs plan steps in sequence, delegating to the appropriate healer
+(entity, device, or integration) based on each step's level. Records
+execution results in the database for tracking and analysis.
+"""
+
+import asyncio
+import logging
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+
+from sqlalchemy import select
+
+from ha_boss.core.database import Database, HealingPlan, HealingPlanExecution
+from ha_boss.healing.cascade_orchestrator import HealingContext
+from ha_boss.healing.device_healer import DeviceHealer
+from ha_boss.healing.entity_healer import EntityHealer
+from ha_boss.healing.plan_models import HealingPlanDefinition, HealingStep
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class StepResult:
+    """Result of executing a single plan step."""
+
+    step_name: str
+    level: str
+    action: str
+    success: bool
+    duration_seconds: float
+    error_message: str | None = None
+
+
+@dataclass
+class PlanExecutionResult:
+    """Result of executing a complete healing plan."""
+
+    plan_name: str
+    success: bool
+    steps_attempted: list[StepResult] = field(default_factory=list)
+    steps_succeeded: int = 0
+    steps_failed: int = 0
+    total_duration_seconds: float = 0.0
+    error_message: str | None = None
+
+
+class PlanExecutor:
+    """Execute healing plans using existing healer infrastructure.
+
+    Each plan step is executed in order. If a step succeeds, execution
+    stops early (the entity is healed). If a step fails, the next step
+    is tried. After all steps, the overall result is recorded.
+    """
+
+    def __init__(
+        self,
+        database: Database,
+        entity_healer: EntityHealer,
+        device_healer: DeviceHealer,
+    ) -> None:
+        """Initialize plan executor.
+
+        Args:
+            database: Database for recording execution results
+            entity_healer: Entity-level healer
+            device_healer: Device-level healer
+        """
+        self.database = database
+        self.entity_healer = entity_healer
+        self.device_healer = device_healer
+
+    async def execute_plan(
+        self,
+        plan: HealingPlanDefinition,
+        context: HealingContext,
+        cascade_execution_id: int | None = None,
+    ) -> PlanExecutionResult:
+        """Execute a healing plan for the given context.
+
+        Steps are executed in order. Execution stops early on first
+        successful step (entity is healed). Records results to database.
+
+        Args:
+            plan: Plan definition to execute
+            context: Healing context with failed entities
+            cascade_execution_id: Optional link to cascade execution
+
+        Returns:
+            PlanExecutionResult with step-by-step results
+        """
+        start_time = datetime.now(UTC)
+        step_results: list[StepResult] = []
+        steps_succeeded = 0
+        steps_failed = 0
+        overall_success = False
+
+        logger.info(
+            f"Executing plan '{plan.name}' for {context.automation_id} "
+            f"({len(context.failed_entities)} entities, {len(plan.steps)} steps)"
+        )
+
+        for step in plan.steps:
+            step_start = datetime.now(UTC)
+
+            try:
+                success = await asyncio.wait_for(
+                    self._execute_step(step, context),
+                    timeout=step.timeout_seconds,
+                )
+            except TimeoutError:
+                success = False
+                error_msg = f"Step '{step.name}' timed out after {step.timeout_seconds}s"
+                logger.warning(error_msg)
+                step_duration = step.timeout_seconds
+                step_results.append(
+                    StepResult(
+                        step_name=step.name,
+                        level=step.level,
+                        action=step.action,
+                        success=False,
+                        duration_seconds=step_duration,
+                        error_message=error_msg,
+                    )
+                )
+                steps_failed += 1
+                continue
+            except Exception as e:
+                success = False
+                error_msg = f"Step '{step.name}' failed: {e}"
+                logger.error(error_msg, exc_info=True)
+                step_duration = (datetime.now(UTC) - step_start).total_seconds()
+                step_results.append(
+                    StepResult(
+                        step_name=step.name,
+                        level=step.level,
+                        action=step.action,
+                        success=False,
+                        duration_seconds=step_duration,
+                        error_message=error_msg,
+                    )
+                )
+                steps_failed += 1
+                continue
+
+            step_duration = (datetime.now(UTC) - step_start).total_seconds()
+            step_results.append(
+                StepResult(
+                    step_name=step.name,
+                    level=step.level,
+                    action=step.action,
+                    success=success,
+                    duration_seconds=step_duration,
+                )
+            )
+
+            if success:
+                steps_succeeded += 1
+                overall_success = True
+                logger.info(
+                    f"Plan '{plan.name}' step '{step.name}' succeeded "
+                    f"for {context.automation_id}"
+                )
+                break
+            else:
+                steps_failed += 1
+                logger.info(
+                    f"Plan '{plan.name}' step '{step.name}' failed "
+                    f"for {context.automation_id}, trying next step"
+                )
+
+        total_duration = (datetime.now(UTC) - start_time).total_seconds()
+
+        result = PlanExecutionResult(
+            plan_name=plan.name,
+            success=overall_success,
+            steps_attempted=step_results,
+            steps_succeeded=steps_succeeded,
+            steps_failed=steps_failed,
+            total_duration_seconds=total_duration,
+        )
+
+        # Record execution in database
+        await self._record_execution(
+            plan=plan,
+            context=context,
+            result=result,
+            cascade_execution_id=cascade_execution_id,
+            started_at=start_time,
+        )
+
+        logger.info(
+            f"Plan '{plan.name}' execution {'succeeded' if overall_success else 'failed'} "
+            f"for {context.automation_id} "
+            f"({steps_succeeded} succeeded, {steps_failed} failed, "
+            f"{total_duration:.1f}s total)"
+        )
+
+        return result
+
+    async def _execute_step(self, step: HealingStep, context: HealingContext) -> bool:
+        """Execute a single plan step.
+
+        Delegates to the appropriate healer based on the step's level.
+
+        Args:
+            step: Step to execute
+            context: Healing context
+
+        Returns:
+            True if step succeeded
+        """
+        if step.level == "entity":
+            return await self._execute_entity_step(step, context)
+        elif step.level == "device":
+            return await self._execute_device_step(step, context)
+        elif step.level == "integration":
+            return await self._execute_integration_step(step, context)
+        else:
+            logger.error(f"Unknown step level: {step.level}")
+            return False
+
+    async def _execute_entity_step(self, step: HealingStep, context: HealingContext) -> bool:
+        """Execute entity-level healing step.
+
+        Heals each failed entity individually. Returns True if any entity
+        was healed successfully.
+        """
+        any_success = False
+        for entity_id in context.failed_entities:
+            result = await self.entity_healer.heal(
+                entity_id=entity_id,
+                triggered_by=context.trigger_type,
+                automation_id=context.automation_id,
+                execution_id=context.execution_id,
+            )
+            if result.success:
+                any_success = True
+        return any_success
+
+    async def _execute_device_step(self, step: HealingStep, context: HealingContext) -> bool:
+        """Execute device-level healing step."""
+        result = await self.device_healer.heal(
+            entity_ids=context.failed_entities,
+            triggered_by=context.trigger_type,
+            automation_id=context.automation_id,
+            execution_id=context.execution_id,
+        )
+        return result.success
+
+    async def _execute_integration_step(self, step: HealingStep, context: HealingContext) -> bool:
+        """Execute integration-level healing step.
+
+        Uses entity healer's retry mechanism since integration reloads
+        affect the same entities. The actual integration reload is
+        triggered indirectly through the device healer which maps
+        entities to their integration config entries.
+        """
+        # For integration-level steps, we use the device healer which
+        # already has the integration reload capability when device-level
+        # actions fail. This ensures consistent behavior.
+        result = await self.device_healer.heal(
+            entity_ids=context.failed_entities,
+            triggered_by=context.trigger_type,
+            automation_id=context.automation_id,
+            execution_id=context.execution_id,
+        )
+        return result.success
+
+    async def _record_execution(
+        self,
+        plan: HealingPlanDefinition,
+        context: HealingContext,
+        result: PlanExecutionResult,
+        cascade_execution_id: int | None,
+        started_at: datetime,
+    ) -> None:
+        """Record plan execution in database."""
+        try:
+            async with self.database.async_session() as session:
+                # Look up plan_id from database
+                plan_id = None
+                db_result = await session.execute(
+                    select(HealingPlan.id).where(HealingPlan.name == plan.name)
+                )
+                row = db_result.scalar_one_or_none()
+                if row is not None:
+                    plan_id = row
+
+                execution = HealingPlanExecution(
+                    plan_id=plan_id or 0,
+                    plan_name=plan.name,
+                    instance_id=context.instance_id,
+                    automation_id=context.automation_id,
+                    cascade_execution_id=cascade_execution_id,
+                    target_entities=[{"entity_id": e} for e in context.failed_entities],
+                    steps_attempted=[
+                        {
+                            "step_name": s.step_name,
+                            "level": s.level,
+                            "action": s.action,
+                            "success": s.success,
+                            "duration_seconds": s.duration_seconds,
+                            "error_message": s.error_message,
+                        }
+                        for s in result.steps_attempted
+                    ],
+                    steps_succeeded=result.steps_succeeded,
+                    steps_failed=result.steps_failed,
+                    overall_success=result.success,
+                    total_duration_seconds=result.total_duration_seconds,
+                    created_at=started_at,
+                    completed_at=datetime.now(UTC),
+                )
+                session.add(execution)
+                await session.commit()
+
+                # Update plan execution stats
+                if plan_id is not None:
+                    db_result2 = await session.execute(
+                        select(HealingPlan).where(HealingPlan.id == plan_id)
+                    )
+                    db_plan = db_result2.scalar_one_or_none()
+                    if db_plan:
+                        db_plan.total_executions = (db_plan.total_executions or 0) + 1
+                        if result.success:
+                            db_plan.successful_executions = (db_plan.successful_executions or 0) + 1
+                        else:
+                            db_plan.failed_executions = (db_plan.failed_executions or 0) + 1
+                        db_plan.last_executed_at = datetime.now(UTC)
+                        await session.commit()
+
+        except Exception as e:
+            logger.error(
+                f"Failed to record plan execution for '{plan.name}': {e}",
+                exc_info=True,
+            )

--- a/tests/healing/test_plan_executor.py
+++ b/tests/healing/test_plan_executor.py
@@ -1,0 +1,453 @@
+"""Tests for plan executor module."""
+
+import asyncio
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from ha_boss.core.database import Database
+from ha_boss.healing.cascade_orchestrator import HealingContext
+from ha_boss.healing.device_healer import DeviceHealer, DeviceHealingResult
+from ha_boss.healing.entity_healer import EntityHealer, EntityHealingResult
+from ha_boss.healing.plan_executor import PlanExecutionResult, PlanExecutor, StepResult
+from ha_boss.healing.plan_models import (
+    HealingPlanDefinition,
+    HealingStep,
+    MatchCriteria,
+)
+
+
+def _make_plan(steps: list[HealingStep]) -> HealingPlanDefinition:
+    return HealingPlanDefinition(
+        name="test_plan",
+        description="Test plan",
+        match=MatchCriteria(entity_patterns=["sensor.*"]),
+        steps=steps,
+    )
+
+
+def _make_context(entities: list[str]) -> HealingContext:
+    return HealingContext(
+        instance_id="test_instance",
+        automation_id="automation.test",
+        execution_id=123,
+        trigger_type="trigger_failure",
+        failed_entities=entities,
+    )
+
+
+def _make_step(name: str, level: str, action: str, timeout_seconds: float = 30.0) -> HealingStep:
+    return HealingStep(name=name, level=level, action=action, timeout_seconds=timeout_seconds)
+
+
+class TestPlanExecutorStepExecution:
+    @pytest.mark.asyncio
+    async def test_entity_step_succeeds(self) -> None:
+        db = Mock(spec=Database)
+        entity_healer = Mock(spec=EntityHealer)
+        device_healer = Mock(spec=DeviceHealer)
+
+        entity_healer.heal = AsyncMock(
+            return_value=EntityHealingResult(
+                entity_id="sensor.test",
+                success=True,
+                actions_attempted=["retry"],
+                final_action="retry",
+                error_message=None,
+                total_duration_seconds=1.0,
+            )
+        )
+
+        executor = PlanExecutor(db, entity_healer, device_healer)
+        step = _make_step("entity_retry", "entity", "retry")
+        context = _make_context(["sensor.test"])
+
+        success = await executor._execute_step(step, context)
+
+        assert success is True
+        entity_healer.heal.assert_awaited_once_with(
+            entity_id="sensor.test",
+            triggered_by="trigger_failure",
+            automation_id="automation.test",
+            execution_id=123,
+        )
+
+    @pytest.mark.asyncio
+    async def test_entity_step_fails(self) -> None:
+        db = Mock(spec=Database)
+        entity_healer = Mock(spec=EntityHealer)
+        device_healer = Mock(spec=DeviceHealer)
+
+        entity_healer.heal = AsyncMock(
+            return_value=EntityHealingResult(
+                entity_id="sensor.test",
+                success=False,
+                actions_attempted=["retry"],
+                final_action=None,
+                error_message="Entity still unavailable",
+                total_duration_seconds=1.0,
+            )
+        )
+
+        executor = PlanExecutor(db, entity_healer, device_healer)
+        step = _make_step("entity_retry", "entity", "retry")
+        context = _make_context(["sensor.test"])
+
+        success = await executor._execute_step(step, context)
+
+        assert success is False
+
+    @pytest.mark.asyncio
+    async def test_device_step_succeeds(self) -> None:
+        db = Mock(spec=Database)
+        entity_healer = Mock(spec=EntityHealer)
+        device_healer = Mock(spec=DeviceHealer)
+
+        device_healer.heal = AsyncMock(
+            return_value=DeviceHealingResult(
+                devices_attempted=["dev1"],
+                success=True,
+                devices_healed=["dev1"],
+                actions_attempted=["reconnect"],
+                final_action="reconnect",
+                error_message=None,
+                total_duration_seconds=1.0,
+            )
+        )
+
+        executor = PlanExecutor(db, entity_healer, device_healer)
+        step = _make_step("device_reconnect", "device", "reconnect")
+        context = _make_context(["sensor.test"])
+
+        success = await executor._execute_step(step, context)
+
+        assert success is True
+        device_healer.heal.assert_awaited_once_with(
+            entity_ids=["sensor.test"],
+            triggered_by="trigger_failure",
+            automation_id="automation.test",
+            execution_id=123,
+        )
+
+    @pytest.mark.asyncio
+    async def test_device_step_fails(self) -> None:
+        db = Mock(spec=Database)
+        entity_healer = Mock(spec=EntityHealer)
+        device_healer = Mock(spec=DeviceHealer)
+
+        device_healer.heal = AsyncMock(
+            return_value=DeviceHealingResult(
+                devices_attempted=["dev1"],
+                success=False,
+                devices_healed=[],
+                actions_attempted=["reconnect"],
+                final_action=None,
+                error_message="Device unreachable",
+                total_duration_seconds=1.0,
+            )
+        )
+
+        executor = PlanExecutor(db, entity_healer, device_healer)
+        step = _make_step("device_reconnect", "device", "reconnect")
+        context = _make_context(["sensor.test"])
+
+        success = await executor._execute_step(step, context)
+
+        assert success is False
+
+    @pytest.mark.asyncio
+    async def test_integration_step_delegates_to_device_healer(self) -> None:
+        db = Mock(spec=Database)
+        entity_healer = Mock(spec=EntityHealer)
+        device_healer = Mock(spec=DeviceHealer)
+
+        device_healer.heal = AsyncMock(
+            return_value=DeviceHealingResult(
+                devices_attempted=["dev1"],
+                success=True,
+                devices_healed=["dev1"],
+                actions_attempted=["reload"],
+                final_action="reload",
+                error_message=None,
+                total_duration_seconds=1.0,
+            )
+        )
+
+        executor = PlanExecutor(db, entity_healer, device_healer)
+        step = _make_step("integration_reload", "integration", "reload")
+        context = _make_context(["sensor.test"])
+
+        success = await executor._execute_step(step, context)
+
+        assert success is True
+        device_healer.heal.assert_awaited_once()
+
+    def test_unknown_level_validation(self) -> None:
+        """Pydantic validates level at model creation time."""
+        with pytest.raises(ValueError, match="Invalid level"):
+            _make_step("invalid_step", "unknown_level", "action")
+
+
+class TestPlanExecutorExecution:
+    @pytest.mark.asyncio
+    async def test_first_step_succeeds_stops_early(self) -> None:
+        db = Mock(spec=Database)
+        db.async_session = AsyncMock()
+        entity_healer = Mock(spec=EntityHealer)
+        device_healer = Mock(spec=DeviceHealer)
+
+        entity_healer.heal = AsyncMock(
+            return_value=EntityHealingResult(
+                entity_id="sensor.test",
+                success=True,
+                actions_attempted=["retry"],
+                final_action="retry",
+                error_message=None,
+                total_duration_seconds=1.0,
+            )
+        )
+
+        executor = PlanExecutor(db, entity_healer, device_healer)
+        plan = _make_plan(
+            [
+                _make_step("entity_retry", "entity", "retry"),
+                _make_step("device_reconnect", "device", "reconnect"),
+            ]
+        )
+        context = _make_context(["sensor.test"])
+
+        result = await executor.execute_plan(plan, context)
+
+        assert result.success is True
+        assert result.steps_succeeded == 1
+        assert result.steps_failed == 0
+        assert len(result.steps_attempted) == 1
+        assert result.steps_attempted[0].step_name == "entity_retry"
+        entity_healer.heal.assert_awaited_once()
+        device_healer.heal.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_falls_through_to_second_step(self) -> None:
+        db = Mock(spec=Database)
+        db.async_session = AsyncMock()
+        entity_healer = Mock(spec=EntityHealer)
+        device_healer = Mock(spec=DeviceHealer)
+
+        entity_healer.heal = AsyncMock(
+            return_value=EntityHealingResult(
+                entity_id="sensor.test",
+                success=False,
+                actions_attempted=["retry"],
+                final_action=None,
+                error_message="Still unavailable",
+                total_duration_seconds=1.0,
+            )
+        )
+
+        device_healer.heal = AsyncMock(
+            return_value=DeviceHealingResult(
+                devices_attempted=["dev1"],
+                success=True,
+                devices_healed=["dev1"],
+                actions_attempted=["reconnect"],
+                final_action="reconnect",
+                error_message=None,
+                total_duration_seconds=1.0,
+            )
+        )
+
+        executor = PlanExecutor(db, entity_healer, device_healer)
+        plan = _make_plan(
+            [
+                _make_step("entity_retry", "entity", "retry"),
+                _make_step("device_reconnect", "device", "reconnect"),
+            ]
+        )
+        context = _make_context(["sensor.test"])
+
+        result = await executor.execute_plan(plan, context)
+
+        assert result.success is True
+        assert result.steps_succeeded == 1
+        assert result.steps_failed == 1
+        assert len(result.steps_attempted) == 2
+        assert result.steps_attempted[0].success is False
+        assert result.steps_attempted[1].success is True
+        entity_healer.heal.assert_awaited_once()
+        device_healer.heal.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_all_steps_fail(self) -> None:
+        db = Mock(spec=Database)
+        db.async_session = AsyncMock()
+        entity_healer = Mock(spec=EntityHealer)
+        device_healer = Mock(spec=DeviceHealer)
+
+        entity_healer.heal = AsyncMock(
+            return_value=EntityHealingResult(
+                entity_id="sensor.test",
+                success=False,
+                actions_attempted=["retry"],
+                final_action=None,
+                error_message="Failed",
+                total_duration_seconds=1.0,
+            )
+        )
+
+        device_healer.heal = AsyncMock(
+            return_value=DeviceHealingResult(
+                devices_attempted=["dev1"],
+                success=False,
+                devices_healed=[],
+                actions_attempted=["reconnect"],
+                final_action=None,
+                error_message="Failed",
+                total_duration_seconds=1.0,
+            )
+        )
+
+        executor = PlanExecutor(db, entity_healer, device_healer)
+        plan = _make_plan(
+            [
+                _make_step("entity_retry", "entity", "retry"),
+                _make_step("device_reconnect", "device", "reconnect"),
+            ]
+        )
+        context = _make_context(["sensor.test"])
+
+        result = await executor.execute_plan(plan, context)
+
+        assert result.success is False
+        assert result.steps_succeeded == 0
+        assert result.steps_failed == 2
+        assert len(result.steps_attempted) == 2
+
+    @pytest.mark.asyncio
+    async def test_step_timeout(self) -> None:
+        db = Mock(spec=Database)
+        db.async_session = AsyncMock()
+        entity_healer = Mock(spec=EntityHealer)
+        device_healer = Mock(spec=DeviceHealer)
+
+        async def slow_heal(*args, **kwargs):
+            await asyncio.sleep(5.0)
+            return EntityHealingResult(
+                entity_id="sensor.test",
+                success=True,
+                actions_attempted=["retry"],
+                final_action="retry",
+                error_message=None,
+                total_duration_seconds=5.0,
+            )
+
+        entity_healer.heal = AsyncMock(side_effect=slow_heal)
+
+        executor = PlanExecutor(db, entity_healer, device_healer)
+        plan = _make_plan([_make_step("entity_retry", "entity", "retry", timeout_seconds=1)])
+        context = _make_context(["sensor.test"])
+
+        result = await executor.execute_plan(plan, context)
+
+        assert result.success is False
+        assert result.steps_failed == 1
+        assert "timed out" in result.steps_attempted[0].error_message
+
+    @pytest.mark.asyncio
+    async def test_step_exception_continues(self) -> None:
+        db = Mock(spec=Database)
+        db.async_session = AsyncMock()
+        entity_healer = Mock(spec=EntityHealer)
+        device_healer = Mock(spec=DeviceHealer)
+
+        entity_healer.heal = AsyncMock(side_effect=RuntimeError("Healer error"))
+
+        device_healer.heal = AsyncMock(
+            return_value=DeviceHealingResult(
+                devices_attempted=["dev1"],
+                success=True,
+                devices_healed=["dev1"],
+                actions_attempted=["reconnect"],
+                final_action="reconnect",
+                error_message=None,
+                total_duration_seconds=1.0,
+            )
+        )
+
+        executor = PlanExecutor(db, entity_healer, device_healer)
+        plan = _make_plan(
+            [
+                _make_step("entity_retry", "entity", "retry"),
+                _make_step("device_reconnect", "device", "reconnect"),
+            ]
+        )
+        context = _make_context(["sensor.test"])
+
+        result = await executor.execute_plan(plan, context)
+
+        assert result.success is True
+        assert result.steps_failed == 1
+        assert result.steps_succeeded == 1
+        assert "Healer error" in result.steps_attempted[0].error_message
+
+    @pytest.mark.asyncio
+    async def test_records_to_database(self) -> None:
+        mock_session = AsyncMock()
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=None)
+        mock_session.execute = AsyncMock()
+        mock_session.execute.return_value.scalar_one_or_none = Mock(return_value=None)
+        mock_session.commit = AsyncMock()
+
+        db = Mock(spec=Database)
+        db.async_session = Mock(return_value=mock_session)
+
+        entity_healer = Mock(spec=EntityHealer)
+        device_healer = Mock(spec=DeviceHealer)
+
+        entity_healer.heal = AsyncMock(
+            return_value=EntityHealingResult(
+                entity_id="sensor.test",
+                success=True,
+                actions_attempted=["retry"],
+                final_action="retry",
+                error_message=None,
+                total_duration_seconds=1.0,
+            )
+        )
+
+        executor = PlanExecutor(db, entity_healer, device_healer)
+        plan = _make_plan([_make_step("entity_retry", "entity", "retry")])
+        context = _make_context(["sensor.test"])
+
+        result = await executor.execute_plan(plan, context)
+
+        assert result.success is True
+        mock_session.add.assert_called_once()
+        assert mock_session.commit.await_count >= 1
+
+
+class TestPlanExecutionResult:
+    def test_result_fields(self) -> None:
+        result = PlanExecutionResult(
+            plan_name="test_plan",
+            success=True,
+            steps_attempted=[
+                StepResult(
+                    step_name="step1",
+                    level="entity",
+                    action="retry",
+                    success=True,
+                    duration_seconds=1.5,
+                )
+            ],
+            steps_succeeded=1,
+            steps_failed=0,
+            total_duration_seconds=2.0,
+        )
+
+        assert result.plan_name == "test_plan"
+        assert result.success is True
+        assert len(result.steps_attempted) == 1
+        assert result.steps_succeeded == 1
+        assert result.steps_failed == 0
+        assert result.total_duration_seconds == 2.0

--- a/tests/healing/test_plan_executor.py
+++ b/tests/healing/test_plan_executor.py
@@ -4,17 +4,17 @@ import asyncio
 from unittest.mock import AsyncMock, Mock
 
 import pytest
-from ha_boss.healing.plan_models import (
-    HealingPlanDefinition,
-    HealingStep,
-    MatchCriteria,
-)
 
 from ha_boss.core.database import Database
 from ha_boss.healing.cascade_orchestrator import HealingContext
 from ha_boss.healing.device_healer import DeviceHealer, DeviceHealingResult
 from ha_boss.healing.entity_healer import EntityHealer, EntityHealingResult
 from ha_boss.healing.plan_executor import PlanExecutionResult, PlanExecutor, StepResult
+from ha_boss.healing.plan_models import (
+    HealingPlanDefinition,
+    HealingStep,
+    MatchCriteria,
+)
 
 
 def _make_plan(steps: list[HealingStep]) -> HealingPlanDefinition:

--- a/tests/healing/test_plan_executor.py
+++ b/tests/healing/test_plan_executor.py
@@ -4,17 +4,17 @@ import asyncio
 from unittest.mock import AsyncMock, Mock
 
 import pytest
+from ha_boss.healing.plan_models import (
+    HealingPlanDefinition,
+    HealingStep,
+    MatchCriteria,
+)
 
 from ha_boss.core.database import Database
 from ha_boss.healing.cascade_orchestrator import HealingContext
 from ha_boss.healing.device_healer import DeviceHealer, DeviceHealingResult
 from ha_boss.healing.entity_healer import EntityHealer, EntityHealingResult
 from ha_boss.healing.plan_executor import PlanExecutionResult, PlanExecutor, StepResult
-from ha_boss.healing.plan_models import (
-    HealingPlanDefinition,
-    HealingStep,
-    MatchCriteria,
-)
 
 
 def _make_plan(steps: list[HealingStep]) -> HealingPlanDefinition:


### PR DESCRIPTION
## Summary
- Implements `PlanExecutor` class that executes healing plan steps in order
- Delegates to existing `EntityHealer` and `DeviceHealer` based on step level
- Per-step timeout handling via `asyncio.wait_for`
- Stops early on first successful step
- Records execution history and updates plan stats in database

## Changes
- `ha_boss/healing/plan_executor.py` — New PlanExecutor, StepResult, PlanExecutionResult
- `tests/healing/test_plan_executor.py` — 13 tests covering all execution paths

## Test plan
- [x] All 13 plan executor tests pass
- [x] Black formatting passes
- [x] Ruff linting passes

Part of Epic #177 Phase 3: Healing Plan Framework (PR 4 of 8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)