### PR TITLE
feat: enrich LLM system prompts with HA domain knowledge

### DIFF
--- a/ha_boss/automation/analyzer.py
+++ b/ha_boss/automation/analyzer.py
@@ -507,7 +507,18 @@ class AutomationAnalyzer:
         system_prompt = (
             "You are a Home Assistant automation expert. Analyze the automation "
             "and provide specific, actionable suggestions. Focus on efficiency, "
-            "reliability, and best practices. Be concise but helpful."
+            "reliability, and best practices. Be concise but helpful.\n\n"
+            "Home Assistant automation best practices:\n"
+            "- Use trigger IDs (id: field) when multiple triggers exist for clarity in conditions\n"
+            "- Debounce noisy sensors with `for:` on triggers to avoid rapid-fire executions\n"
+            "- Use `choose` action for multi-branch logic instead of multiple `if` blocks\n"
+            "- Prefer `wait_for_trigger` with timeout over bare `delay` for sequential logic\n"
+            "- Use `mode: queued` or `mode: single` instead of `mode: restart` for long-running automations\n"
+            "- Target `area_id` or `device_id` instead of listing entity_ids where possible\n"
+            "- Prefer domain-specific services (light.turn_on, switch.turn_off) over homeassistant.turn_on\n"
+            "- Use `response_variable` with action calls that return data rather than separate state reads\n"
+            "- Avoid `platform: state` triggers without `to:` — they fire on attribute changes too\n"
+            "- Use `condition: state` with `for:` to confirm state has been held before acting"
         )
 
         try:

--- a/ha_boss/healing/plan_generator.py
+++ b/ha_boss/healing/plan_generator.py
@@ -51,6 +51,27 @@ Schema:
       timeout_seconds: 30
   tags: ["tag1"]
 
+Action semantics:
+- retry_service_call: re-fires the last HA service call; best for transient entity-level errors
+- reconnect: re-establishes the protocol connection (TCP socket, serial port, USB)
+- reload_integration: reloads the config entry non-destructively; fast, low disruption
+- rediscover: triggers device/entity re-discovery; use when entities go missing after reload
+- reboot: restarts the Home Assistant process; highest disruption, last resort only
+
+Integration-specific recovery order (prefer least-disruptive first):
+- zha (Zigbee): reload_integration → rediscover → reboot
+- zwave_js: reload_integration → rediscover (dead nodes) → reconnect (USB controller lost)
+- mqtt: reload_integration (broker reconnects automatically on reload)
+- esphome: retry_service_call → reload_integration (device likely rebooted or lost WiFi)
+- homekit_controller: reload_integration → rediscover (lost pairing)
+- generic/unknown: retry_service_call (entity) → reload_integration (integration) → reboot
+
+Priority guidance:
+- 90-100: all entities in an integration unavailable simultaneously
+- 60-89: partial failure or repeated single-entity errors
+- 30-59: degraded reliability, intermittent failures
+- 0-29: optional optimizations
+
 Return ONLY valid YAML, no explanation."""
 
     def __init__(self, llm_router: LLMRouter) -> None:

--- a/ha_boss/notifications/enhanced_generator.py
+++ b/ha_boss/notifications/enhanced_generator.py
@@ -164,6 +164,15 @@ SUGGESTIONS:
 2. [Second suggestion]
 3. [Third suggestion if needed]
 
+Common integration failure patterns to recognise:
+- ZHA/Zigbee: "unavailable" usually means coordinator lost radio contact; reload integration before blaming the device
+- Z-Wave JS: node unavailable → check USB controller connection; "interview failed" → rediscover the node
+- MQTT: entities unavailable → broker likely restarted or network interrupted; check broker logs first
+- ESPHome: "Transport closed" or "Connection refused" → device rebooted or lost WiFi; check device logs via ESPHome dashboard
+- HomeKit: pairing lost → remove and re-add the accessory in HA
+- Cloud integrations (Google Home, Alexa, Nabu Casa): token expiry → re-authenticate via HA integrations UI
+- Network-dependent integrations: verify HA host network connectivity before assuming integration fault
+
 Be concise and practical. Focus on the most likely causes and solutions."""
 
     def _parse_response(self, response: str) -> dict[str, str]:


### PR DESCRIPTION
## Summary

- **plan_generator**: adds action semantics, per-integration recovery order (zha, zwave_js, mqtt, esphome, homekit_controller), and priority guidance so generated healing plans choose the least-disruptive action first
- **automation/analyzer**: adds 10 HA automation best practices (trigger IDs, debounce with `for:`, `choose` over nested `if`, `mode` selection, service deprecations, etc.)
- **notifications/enhanced_generator**: adds integration failure pattern recognition (ZHA, Z-Wave JS, MQTT, ESPHome, HomeKit, cloud token expiry) so failure analysis is grounded in known root causes

No infrastructure changes — this is pure system prompt enrichment. Pairs with the switch to `qwen3:8b-nothink` as the local model.

## Test plan

- [ ] Start Ollama with `qwen3:8b-nothink` loaded
- [ ] Trigger a ZHA unavailable failure and verify healing plan prefers `reload_integration` over `reboot`
- [ ] Verify automation analyzer suggestions reference HA-specific patterns (not generic advice)
- [ ] Verify failure notifications include integration-specific root cause language

🤖 Generated with [Claude Code](https://claude.com/claude-code)