### PR TITLE
fix: treat 'unavailable' as expected for configured entities

### DIFF
--- a/config/config.yaml.example
+++ b/config/config.yaml.example
@@ -50,6 +50,16 @@ monitoring:
     - "sensor.uptime*"
     - "sun.sun"
 
+  # Entities for which the 'unavailable' state is EXPECTED/normal (glob patterns).
+  # Some devices report 'unavailable' simply because they are powered off (e.g. a
+  # TV or media player). Matching entities are NOT flagged as unavailable/stale by
+  # the health monitor, and a turn_off that leaves them unavailable is treated as
+  # success by the action verifier. Leave empty unless a device legitimately drops
+  # to 'unavailable' when off.
+  unavailable_ok: []
+  # Example:
+  #   - "media_player.lg_webos_tv_oled65c8pua"
+
   # Grace period before considering entity truly unavailable (seconds)
   grace_period_seconds: 300  # 5 minutes
 

--- a/ha_boss/core/config.py
+++ b/ha_boss/core/config.py
@@ -1,5 +1,6 @@
 """Configuration management with Pydantic."""
 
+import fnmatch
 import os
 from pathlib import Path
 from typing import Any, Literal
@@ -247,6 +248,16 @@ class MonitoringConfig(BaseSettings):
         ],
         description="Entity patterns to exclude from monitoring",
     )
+    unavailable_ok: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Entity patterns for which the 'unavailable' state is expected/normal "
+            "(e.g. a TV or media player that reports unavailable when powered off). "
+            "Matching entities are not flagged as unavailable/stale by the health "
+            "monitor, and a turn_off that leaves them unavailable is treated as "
+            "success by the action verifier."
+        ),
+    )
     grace_period_seconds: int = Field(
         default=300,
         description="Default grace period before entity considered unavailable",
@@ -305,6 +316,20 @@ class MonitoringConfig(BaseSettings):
         if override and override.grace_period_seconds is not None:
             return override.grace_period_seconds
         return self.grace_period_seconds
+
+    def is_unavailable_expected(self, entity_id: str) -> bool:
+        """Check if 'unavailable' is an expected/normal state for an entity.
+
+        Used to suppress false-positive alerts for devices that report
+        ``unavailable`` when they are simply powered off (e.g. TVs).
+
+        Args:
+            entity_id: Entity to check against the ``unavailable_ok`` patterns.
+
+        Returns:
+            True if the entity matches any ``unavailable_ok`` pattern.
+        """
+        return any(fnmatch.fnmatch(entity_id, pattern) for pattern in self.unavailable_ok)
 
 
 class HealingConfig(BaseSettings):

--- a/ha_boss/monitoring/action_verifier.py
+++ b/ha_boss/monitoring/action_verifier.py
@@ -295,6 +295,20 @@ class ActionVerifier:
                 )
                 return
 
+            # Some entities (e.g. a TV/media player) report 'unavailable' as their
+            # normal powered-off state, so a successful turn_off lands on
+            # 'unavailable' rather than 'off'. Treat that as success.
+            if (
+                actual == "unavailable"
+                and expected == "off"
+                and self.config.monitoring.is_unavailable_expected(entity_id)
+            ):
+                logger.debug(
+                    f"[{self.instance_id}] action_verifier: {entity_id} is 'unavailable' after "
+                    f"turn_off — accepted as expected powered-off state (unavailable_ok)"
+                )
+                return
+
             # State mismatch — send WARNING notification
             logger.warning(
                 f"[{self.instance_id}] action_verifier: {entity_id} did NOT reach expected "

--- a/ha_boss/monitoring/health_monitor.py
+++ b/ha_boss/monitoring/health_monitor.py
@@ -126,6 +126,11 @@ class HealthMonitor:
 
         # Check for unavailable state
         if state == "unavailable":
+            # Some entities (e.g. a TV/media player) report 'unavailable' as their
+            # normal powered-off state. For those, unavailable is healthy and we
+            # skip the stale check too (an off device naturally stops updating).
+            if self.config.monitoring.is_unavailable_expected(entity_state.entity_id):
+                return None
             return "unavailable"
 
         # Check for unknown state

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 import pytest
 import yaml
 
-from ha_boss.core.config import Config, load_config
+from ha_boss.core.config import Config, MonitoringConfig, load_config
 from ha_boss.core.exceptions import ConfigurationError
 
 
@@ -185,3 +185,24 @@ def test_load_config_missing_required_fields(tmp_path, monkeypatch):
 
     with pytest.raises(ConfigurationError, match="Invalid configuration"):
         load_config(config_file)
+
+
+def test_is_unavailable_expected_default_empty():
+    """By default no entity is treated as expectedly-unavailable."""
+    cfg = MonitoringConfig()
+    assert cfg.unavailable_ok == []
+    assert cfg.is_unavailable_expected("media_player.lg_webos_tv_oled65c8pua") is False
+
+
+def test_is_unavailable_expected_exact_match():
+    """An exact entity_id in unavailable_ok matches."""
+    cfg = MonitoringConfig(unavailable_ok=["media_player.lg_webos_tv_oled65c8pua"])
+    assert cfg.is_unavailable_expected("media_player.lg_webos_tv_oled65c8pua") is True
+    assert cfg.is_unavailable_expected("light.back_patio") is False
+
+
+def test_is_unavailable_expected_glob_match():
+    """Glob patterns in unavailable_ok match by wildcard."""
+    cfg = MonitoringConfig(unavailable_ok=["media_player.*"])
+    assert cfg.is_unavailable_expected("media_player.kitchen") is True
+    assert cfg.is_unavailable_expected("switch.fan") is False

--- a/tests/monitoring/test_action_verifier.py
+++ b/tests/monitoring/test_action_verifier.py
@@ -381,6 +381,67 @@ class TestVerification:
             assert call_args.kwargs.get("channels") is None
 
 
+class TestUnavailableOkOnTurnOff:
+    """Tests for treating 'unavailable' as a successful turn_off for unavailable_ok entities."""
+
+    def _verifier_with_unavailable_ok(
+        self,
+        patterns: list[str],
+        actual_state: str,
+        notification_manager: AsyncMock,
+    ) -> ActionVerifier:
+        """Build a verifier whose target returns ``actual_state`` and has the given patterns."""
+        ha_client = AsyncMock()
+        ha_client.get_state = AsyncMock(return_value={"state": actual_state, "attributes": {}})
+        cfg = _make_config(delay_seconds=1)
+        cfg.monitoring.action_verification.delay_seconds = 0  # type: ignore[assignment]
+        cfg.monitoring.unavailable_ok = patterns
+        return ActionVerifier(
+            ha_client=ha_client,
+            notification_manager=notification_manager,
+            config=cfg,
+            instance_id="default",
+        )
+
+    @pytest.mark.asyncio
+    async def test_unavailable_after_turn_off_is_success(self) -> None:
+        """A TV that goes 'unavailable' after turn_off is treated as success (no warning)."""
+        notification_manager = AsyncMock()
+        verifier = self._verifier_with_unavailable_ok(
+            ["media_player.lg_webos_tv_oled65c8pua"], "unavailable", notification_manager
+        )
+
+        await verifier._verify(
+            "media_player.lg_webos_tv_oled65c8pua", "off", "media_player", "turn_off"
+        )
+
+        notification_manager.notify.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_unavailable_not_in_list_still_warns(self) -> None:
+        """An entity NOT in unavailable_ok still warns when it lands on 'unavailable'."""
+        notification_manager = AsyncMock()
+        verifier = self._verifier_with_unavailable_ok(
+            ["media_player.lg_webos_tv_oled65c8pua"], "unavailable", notification_manager
+        )
+
+        await verifier._verify("light.back_patio", "off", "light", "turn_off")
+
+        notification_manager.notify.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_unavailable_after_turn_on_still_warns(self) -> None:
+        """unavailable_ok only excuses turn_off; a turn_on landing on 'unavailable' still warns."""
+        notification_manager = AsyncMock()
+        verifier = self._verifier_with_unavailable_ok(
+            ["switch.flaky"], "unavailable", notification_manager
+        )
+
+        await verifier._verify("switch.flaky", "on", "switch", "turn_on")
+
+        notification_manager.notify.assert_called_once()
+
+
 # ---------------------------------------------------------------------------
 # Tests: supersede semantics
 # ---------------------------------------------------------------------------

--- a/tests/monitoring/test_health_monitor.py
+++ b/tests/monitoring/test_health_monitor.py
@@ -137,6 +137,42 @@ class TestHealthMonitorDetection:
         issue_type = health_monitor._detect_issue_type(entity_state)
         assert issue_type is None
 
+    def test_unavailable_ok_suppresses_unavailable(self, health_monitor: HealthMonitor) -> None:
+        """An entity in unavailable_ok is healthy when unavailable (e.g. TV off)."""
+        health_monitor.config.monitoring.unavailable_ok = ["media_player.lg_webos_tv_oled65c8pua"]
+        entity_state = EntityState(
+            entity_id="media_player.lg_webos_tv_oled65c8pua",
+            state="unavailable",
+            last_updated=datetime.now(UTC),
+        )
+
+        assert health_monitor._detect_issue_type(entity_state) is None
+
+    def test_unavailable_ok_also_suppresses_stale(self, health_monitor: HealthMonitor) -> None:
+        """A powered-off unavailable_ok entity stops updating; it must not be flagged stale."""
+        health_monitor.config.monitoring.unavailable_ok = ["media_player.*"]
+        old_time = datetime.now(UTC) - timedelta(hours=2)
+        entity_state = EntityState(
+            entity_id="media_player.lg_webos_tv_oled65c8pua",
+            state="unavailable",
+            last_updated=old_time,
+        )
+
+        assert health_monitor._detect_issue_type(entity_state) is None
+
+    def test_unavailable_ok_does_not_affect_other_entities(
+        self, health_monitor: HealthMonitor
+    ) -> None:
+        """unavailable_ok must not suppress unavailable for non-matching entities."""
+        health_monitor.config.monitoring.unavailable_ok = ["media_player.lg_webos_tv_oled65c8pua"]
+        entity_state = EntityState(
+            entity_id="light.back_patio",
+            state="unavailable",
+            last_updated=datetime.now(UTC),
+        )
+
+        assert health_monitor._detect_issue_type(entity_state) == "unavailable"
+
 
 class TestHealthMonitorGracePeriod:
     """Tests for grace period handling."""


### PR DESCRIPTION
## Summary

Some entities (e.g. `media_player.lg_webos_tv_oled65c8pua`) report `unavailable` as their normal **powered-off** state. This caused two false positives:

- the **health monitor** flagged them as unavailable/stale when simply off
- the **action verifier** warned that a successful `turn_off` "failed" because the entity landed on `unavailable` instead of `off`

## Change

- New `monitoring.unavailable_ok` glob list + `MonitoringConfig.is_unavailable_expected()`
- `HealthMonitor`: matching entities in `unavailable` are healthy (also skips the stale check — an off device stops updating)
- `ActionVerifier`: a `turn_off` that lands a matching entity on `unavailable` is treated as success. A `turn_on` that stays `unavailable` still warns.
- Documented the option in `config.yaml.example`

## Tests

+9 tests (3 health monitor, 3 action verifier, 3 config). Full suite **92 passed**; black/ruff/mypy clean on the changed modules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)