### PR TITLE
fix: wire entity/integration discovery into StateTracker (scoping leak)

### DIFF
--- a/ha_boss/service/main.py
+++ b/ha_boss/service/main.py
@@ -255,6 +255,14 @@ class HABossService:
         self.state_trackers[instance_id] = StateTracker(
             instance_id=instance_id,
             database=self.database,
+            # Wire in discovery so the tracker only caches (and the health monitor
+            # only checks) entities that auto-discovery found in automations/scenes/
+            # scripts. Without this the REST snapshot below loads ALL entities
+            # unfiltered, the monitored set is effectively "everything", and
+            # unreferenced cloud entities (PSN, Plex, Life360) get flagged when they
+            # flap. integration_discovery feeds entity→integration mapping.
+            entity_discovery=self.entity_discoveries.get(instance_id),
+            integration_discovery=self.integration_discoveries.get(instance_id),
             on_state_updated=on_state_updated_wrapper,
         )
 

--- a/tests/service/test_main.py
+++ b/tests/service/test_main.py
@@ -169,6 +169,14 @@ class TestHABossServiceStart:
             assert mock_client.get_states.call_count == 3
             # Note: StateTracker.initialize() is no longer called in multi-instance architecture
             mock_monitor.start.assert_called_once()
+
+            # Regression: the StateTracker MUST be wired with the discovery services,
+            # otherwise its cache (and thus the health monitor) is never scoped to the
+            # discovered set and every entity — including unreferenced cloud ones like
+            # PSN/Plex — gets monitored and flagged when it flaps.
+            tracker_kwargs = mock_state_tracker.call_args.kwargs
+            assert tracker_kwargs.get("entity_discovery") is mock_entity_disc
+            assert tracker_kwargs.get("integration_discovery") is mock_discovery
             # WebSocket now uses start() instead of connect() for initialization
             mock_ws.start.assert_called_once()
 


### PR DESCRIPTION
## Problem

ha_boss was sending issue-detected notifications (HA + **mobile push**) for entities that arent referenced in any automation/scene/script — e.g. PlayStation Network cloud sensors — whenever those cloud integrations flapped to `unavailable`.

## Root cause

In `_initialize_instance`, the `StateTracker` was constructed **without** `entity_discovery` (or `integration_discovery`). With `self.entity_discovery is None`:

- `initialize()` / `update_state()` skip their discovery filter → the REST snapshot loads **all** entities into the cache
- `refresh_monitored_set()` returns early → the periodic prune is a **no-op**

So auto-discovery scoping was completely inert: the health monitor checked **every** entity, and unreferenced cloud entities (PSN/Plex/Life360) got flagged when they dropped.

## Fix

Pass `entity_discovery` and `integration_discovery` into the `StateTracker` so only the discovered set (automation/scene/script-referenced entities) is cached and monitored, as designed. Unreferenced cloud entities now fall to the out-of-scope audit (INFO digest, no mobile push) instead of paging.

## Tests

Regression assertion added to `test_start_initializes_components` (StateTracker must receive the discovery services). Full suite: 1357 passed locally; black/ruff clean.

> Note: a separate pre-existing test, `test_templates.py::test_format_time_ago_naive_datetime`, is DST-sensitive and fails on a `America/Chicago` (CDT) host but passes in UTC CI — unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)