### PR TITLE
fix: resolve all mypy errors + enforce mypy in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,6 @@ jobs:
 
     - name: Run mypy (type check)
       run: mypy ha_boss
-      continue-on-error: true
 
     - name: Run pytest
       run: |

--- a/ha_boss/core/ha_client.py
+++ b/ha_boss/core/ha_client.py
@@ -509,7 +509,7 @@ class HomeAssistantClient:
                 result = await response.json()
                 # Add the ID to the result
                 result["id"] = automation_id
-                return result
+                return cast(dict[str, Any], result)
             elif response.status == 400:
                 error_text = await response.text()
                 raise HomeAssistantAPIError(f"Invalid automation configuration: {error_text}")

--- a/ha_boss/core/migrations/v3_add_instance_id.py
+++ b/ha_boss/core/migrations/v3_add_instance_id.py
@@ -12,11 +12,16 @@ Changes:
 
 import logging
 from datetime import UTC, datetime
+from typing import TYPE_CHECKING
 
 from sqlalchemy import inspect, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ha_boss.core.database import DatabaseVersion
+
+if TYPE_CHECKING:
+    from sqlalchemy.engine import Connection
+    from sqlalchemy.ext.asyncio import AsyncConnection
 
 logger = logging.getLogger(__name__)
 
@@ -91,7 +96,7 @@ async def migrate_v2_to_v3(session: AsyncSession) -> None:
         raise RuntimeError(f"Migration failed: {e}") from e
 
 
-async def _migrate_table(connection, table_name: str) -> None:
+async def _migrate_table(connection: "AsyncConnection", table_name: str) -> None:
     """Migrate a single table to add instance_id.
 
     Uses SQLite's table recreation pattern since ALTER TABLE is limited.
@@ -103,7 +108,7 @@ async def _migrate_table(connection, table_name: str) -> None:
     logger.debug("Migrating table: %s", table_name)
 
     # Check if table exists (must use run_sync for inspection on async connection)
-    def get_table_names(sync_conn):
+    def get_table_names(sync_conn: "Connection") -> list[str]:
         return inspect(sync_conn).get_table_names()
 
     existing_tables = await connection.run_sync(get_table_names)
@@ -142,7 +147,7 @@ async def _migrate_table(connection, table_name: str) -> None:
         await _migrate_discovery_refreshes_table(connection)
 
 
-async def _migrate_entities_table(connection) -> None:
+async def _migrate_entities_table(connection: "AsyncConnection") -> None:
     """Migrate entities table: entity_id (PK) → id (PK) + instance_id + entity_id."""
     await connection.execute(text("""
         CREATE TABLE entities_new (
@@ -200,7 +205,7 @@ async def _migrate_entities_table(connection) -> None:
     await connection.execute(text("ALTER TABLE entities_new RENAME TO entities"))
 
 
-async def _migrate_health_events_table(connection) -> None:
+async def _migrate_health_events_table(connection: "AsyncConnection") -> None:
     """Migrate health_events table."""
     await connection.execute(text("""
         CREATE TABLE health_events_new (
@@ -244,7 +249,7 @@ async def _migrate_health_events_table(connection) -> None:
     await connection.execute(text("ALTER TABLE health_events_new RENAME TO health_events"))
 
 
-async def _migrate_healing_actions_table(connection) -> None:
+async def _migrate_healing_actions_table(connection: "AsyncConnection") -> None:
     """Migrate healing_actions table."""
     await connection.execute(text("""
         CREATE TABLE healing_actions_new (
@@ -294,7 +299,7 @@ async def _migrate_healing_actions_table(connection) -> None:
     await connection.execute(text("ALTER TABLE healing_actions_new RENAME TO healing_actions"))
 
 
-async def _migrate_integrations_table(connection) -> None:
+async def _migrate_integrations_table(connection: "AsyncConnection") -> None:
     """Migrate integrations table: entry_id (PK) → id (PK) + instance_id + entry_id."""
     await connection.execute(text("""
         CREATE TABLE integrations_new (
@@ -347,7 +352,7 @@ async def _migrate_integrations_table(connection) -> None:
     await connection.execute(text("ALTER TABLE integrations_new RENAME TO integrations"))
 
 
-async def _migrate_state_history_table(connection) -> None:
+async def _migrate_state_history_table(connection: "AsyncConnection") -> None:
     """Migrate state_history table."""
     await connection.execute(text("""
         CREATE TABLE state_history_new (
@@ -387,7 +392,7 @@ async def _migrate_state_history_table(connection) -> None:
     await connection.execute(text("ALTER TABLE state_history_new RENAME TO state_history"))
 
 
-async def _migrate_integration_reliability_table(connection) -> None:
+async def _migrate_integration_reliability_table(connection: "AsyncConnection") -> None:
     """Migrate integration_reliability table."""
     await connection.execute(text("""
         CREATE TABLE integration_reliability_new (
@@ -443,7 +448,7 @@ async def _migrate_integration_reliability_table(connection) -> None:
     )
 
 
-async def _migrate_integration_metrics_table(connection) -> None:
+async def _migrate_integration_metrics_table(connection: "AsyncConnection") -> None:
     """Migrate integration_metrics table."""
     await connection.execute(text("""
         CREATE TABLE integration_metrics_new (
@@ -497,7 +502,7 @@ async def _migrate_integration_metrics_table(connection) -> None:
     )
 
 
-async def _migrate_automations_table(connection) -> None:
+async def _migrate_automations_table(connection: "AsyncConnection") -> None:
     """Migrate automations table: entity_id (PK) → id (PK) + instance_id + entity_id."""
     await connection.execute(text("""
         CREATE TABLE automations_new (
@@ -548,7 +553,7 @@ async def _migrate_automations_table(connection) -> None:
     await connection.execute(text("ALTER TABLE automations_new RENAME TO automations"))
 
 
-async def _migrate_scenes_table(connection) -> None:
+async def _migrate_scenes_table(connection: "AsyncConnection") -> None:
     """Migrate scenes table."""
     await connection.execute(text("""
         CREATE TABLE scenes_new (
@@ -592,7 +597,7 @@ async def _migrate_scenes_table(connection) -> None:
     await connection.execute(text("ALTER TABLE scenes_new RENAME TO scenes"))
 
 
-async def _migrate_scripts_table(connection) -> None:
+async def _migrate_scripts_table(connection: "AsyncConnection") -> None:
     """Migrate scripts table."""
     await connection.execute(text("""
         CREATE TABLE scripts_new (
@@ -637,7 +642,7 @@ async def _migrate_scripts_table(connection) -> None:
     await connection.execute(text("ALTER TABLE scripts_new RENAME TO scripts"))
 
 
-async def _migrate_automation_entities_table(connection) -> None:
+async def _migrate_automation_entities_table(connection: "AsyncConnection") -> None:
     """Migrate automation_entities table."""
     await connection.execute(text("""
         CREATE TABLE automation_entities_new (
@@ -700,7 +705,7 @@ async def _migrate_automation_entities_table(connection) -> None:
     )
 
 
-async def _migrate_scene_entities_table(connection) -> None:
+async def _migrate_scene_entities_table(connection: "AsyncConnection") -> None:
     """Migrate scene_entities table."""
     await connection.execute(text("""
         CREATE TABLE scene_entities_new (
@@ -756,7 +761,7 @@ async def _migrate_scene_entities_table(connection) -> None:
     await connection.execute(text("ALTER TABLE scene_entities_new RENAME TO scene_entities"))
 
 
-async def _migrate_script_entities_table(connection) -> None:
+async def _migrate_script_entities_table(connection: "AsyncConnection") -> None:
     """Migrate script_entities table."""
     await connection.execute(text("""
         CREATE TABLE script_entities_new (
@@ -813,7 +818,7 @@ async def _migrate_script_entities_table(connection) -> None:
     await connection.execute(text("ALTER TABLE script_entities_new RENAME TO script_entities"))
 
 
-async def _migrate_discovery_refreshes_table(connection) -> None:
+async def _migrate_discovery_refreshes_table(connection: "AsyncConnection") -> None:
     """Migrate discovery_refreshes table."""
     await connection.execute(text("""
         CREATE TABLE discovery_refreshes_new (

--- a/ha_boss/core/migrations/v6_add_healing_suppression.py
+++ b/ha_boss/core/migrations/v6_add_healing_suppression.py
@@ -58,10 +58,10 @@ async def migrate_v5_to_v6(session: AsyncSession) -> None:
         from ha_boss.core.database import DatabaseVersion
 
         target_version = 6
-        result = await session.execute(
+        version_result = await session.execute(
             select(DatabaseVersion).where(DatabaseVersion.version == target_version)
         )
-        existing_version = result.scalar_one_or_none()
+        existing_version = version_result.scalar_one_or_none()
 
         if existing_version is None:
             new_version = DatabaseVersion(

--- a/ha_boss/discovery/auto_discovery_service.py
+++ b/ha_boss/discovery/auto_discovery_service.py
@@ -88,7 +88,7 @@ class AutoDiscoveryService:
 
     async def discover_all_instances(
         self, trigger_type: str = "manual", trigger_source: str | None = None
-    ) -> dict[str, dict[str, int]]:
+    ) -> dict[str, dict[str, Any]]:
         """Discover entities across all configured instances.
 
         Args:
@@ -103,7 +103,7 @@ class AutoDiscoveryService:
             len(self.config.home_assistant.instances),
         )
 
-        results = {}
+        results: dict[str, dict[str, Any]] = {}
 
         # Discover each instance in parallel
         tasks = [
@@ -117,7 +117,7 @@ class AutoDiscoveryService:
         for instance, result in zip(
             self.config.home_assistant.instances, instance_results, strict=True
         ):
-            if isinstance(result, Exception):
+            if isinstance(result, BaseException):
                 logger.error(
                     "Discovery failed for instance %s: %s",
                     instance.instance_id,

--- a/ha_boss/discovery/bridge_client.py
+++ b/ha_boss/discovery/bridge_client.py
@@ -1,7 +1,7 @@
 """Client for HA Boss Bridge API with auto-detection."""
 
 import logging
-from typing import Any
+from typing import Any, cast
 
 import aiohttp
 
@@ -137,7 +137,7 @@ class BridgeClient:
                     len(automations),
                     self.instance.instance_id,
                 )
-                return automations
+                return cast(list[dict[str, Any]], automations)
 
         except aiohttp.ClientError as e:
             raise HomeAssistantConnectionError(
@@ -179,7 +179,7 @@ class BridgeClient:
                     len(scenes),
                     self.instance.instance_id,
                 )
-                return scenes
+                return cast(list[dict[str, Any]], scenes)
 
         except aiohttp.ClientError as e:
             raise HomeAssistantConnectionError(f"Failed to fetch scenes from bridge: {e}") from e
@@ -219,7 +219,7 @@ class BridgeClient:
                     len(scripts),
                     self.instance.instance_id,
                 )
-                return scripts
+                return cast(list[dict[str, Any]], scripts)
 
         except aiohttp.ClientError as e:
             raise HomeAssistantConnectionError(f"Failed to fetch scripts from bridge: {e}") from e

--- a/ha_boss/service/main.py
+++ b/ha_boss/service/main.py
@@ -143,6 +143,7 @@ class HABossService:
             HomeAssistantAuthError: Authentication failed
         """
         logger.info(f"[{instance_id}] Initializing instance...")
+        assert self.database is not None  # set in start() before instances are initialized
 
         # Initialize statistics for this instance
         self.health_checks_performed[instance_id] = 0


### PR DESCRIPTION
Resolves the 27 mypy errors that were lingering (non-blocking — the CI mypy step was `continue-on-error: true`).

- `migrations/v3_add_instance_id.py`: annotate the table-migration helpers' `connection`/`sync_conn` params + returns (16 no-untyped-def)
- `migrations/v6_add_healing_suppression.py`: rename the second `result` (a `session.execute` Result) so it doesn't clash with the earlier CursorResult
- `core/ha_client.py` + `discovery/bridge_client.py`: `cast()` the `response.json()` Any returns to their declared types (no-any-return)
- `discovery/auto_discovery_service.py`: type the results dict as `dict[str, dict[str, Any]]` and narrow on `BaseException` (what `gather(return_exceptions=True)` yields)
- `service/main.py`: assert `self.database is not None` in `_initialize_instance` (it's set in `start()` before any instance init) so the `Database | None` arg-types resolve

With the tree now mypy-clean, **dropped `continue-on-error` from the CI mypy step** so future type regressions fail the build.

Type-annotation-only changes (plus one `isinstance(Exception)`→`isinstance(BaseException)` narrowing and a `result` rename) — no behavior change. mypy: 0 errors; black/ruff clean; suite 453 passed (only the pre-existing DST test fails, green in UTC CI).
