### PR TITLE
fix: match WebSocket subscription result by id (subscribe race)

### DIFF
--- a/ha_boss/monitoring/websocket_client.py
+++ b/ha_boss/monitoring/websocket_client.py
@@ -140,10 +140,22 @@ class WebSocketClient:
 
         await self._ws.send(json.dumps(subscribe_msg))
 
-        # Wait for subscription confirmation
-        response = json.loads(await self._ws.recv())
-        if not response.get("success"):
-            raise HomeAssistantConnectionError(f"Failed to subscribe to {event_type}: {response}")
+        # Wait for the subscription confirmation, matched by message id.
+        # An already-active subscription can deliver events before this one's
+        # result arrives (events carry the originating subscribe command's id),
+        # so loop until we see our own result and dispatch anything else instead
+        # of mistaking it for the confirmation.
+        while True:
+            response = json.loads(await self._ws.recv())
+            if response.get("type") == "result" and response.get("id") == message_id:
+                if not response.get("success"):
+                    raise HomeAssistantConnectionError(
+                        f"Failed to subscribe to {event_type}: {response}"
+                    )
+                break
+            # Not our result (e.g. an event from a prior subscription) — handle it
+            # so it isn't dropped while we set up the remaining subscriptions.
+            await self._handle_message(response)
 
         logger.info(f"Subscribed to {event_type} events")
 

--- a/tests/monitoring/test_websocket_client.py
+++ b/tests/monitoring/test_websocket_client.py
@@ -164,7 +164,9 @@ async def test_subscribe_events_failure(ws_client):
 
     # Mock subscription failure
     mock_ws.recv = AsyncMock(
-        return_value=json.dumps({"id": 1, "success": False, "error": "Unknown event type"})
+        return_value=json.dumps(
+            {"id": 1, "type": "result", "success": False, "error": "Unknown event type"}
+        )
     )
     mock_ws.send = AsyncMock()
 
@@ -172,6 +174,37 @@ async def test_subscribe_events_failure(ws_client):
         await ws_client.subscribe_events("invalid_event")
 
     assert "Failed to subscribe" in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_subscribe_events_skips_racing_event(ws_client):
+    """A racing event before the subscription result must not break subscription.
+
+    HA delivers events for an already-active subscription with that subscription's
+    id; such a message can arrive before this subscribe's own result.
+    """
+    mock_ws = AsyncMock()
+    ws_client._ws = mock_ws
+    handled: list = []
+    ws_client.on_state_changed = AsyncMock(side_effect=lambda data: handled.append(data))
+
+    # First recv: a state_changed event from a prior subscription (id=1).
+    # Second recv: our actual subscription result (id=2, the second _next_id()).
+    racing_event = {
+        "id": 1,
+        "type": "event",
+        "event": {"event_type": "state_changed", "data": {"entity_id": "sensor.x"}},
+    }
+    our_result = {"id": 2, "type": "result", "success": True}
+    responses = [json.dumps(racing_event), json.dumps(our_result)]
+    mock_ws.recv = AsyncMock(side_effect=responses)
+    mock_ws.send = AsyncMock()
+
+    ws_client._next_id()  # consume id 1 (as if state_changed was subscribed first)
+    await ws_client.subscribe_events("call_service")  # uses id 2
+
+    # The racing event was dispatched, not mistaken for the result.
+    assert handled == [{"entity_id": "sensor.x"}]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Fixes a startup race in `websocket_client.subscribe_events`.

It read exactly one message after sending the subscribe command and assumed it was the confirmation. But Home Assistant delivers events for an already-active subscription using **that subscription's command id**, so a `state_changed` event could arrive before a *later* subscribe's `result` — making e.g. the `call_service` subscription fail on startup. It recovered via reconnect, but noisily (a `Failed to subscribe to call_service` error in the logs).

Fix: loop until we see a message with `type == "result"` and our own message `id`; dispatch any intervening messages (events from prior subscriptions) via `_handle_message` so they aren't dropped. Added a regression test simulating a racing event before the result.

mypy: 0 errors; black/ruff clean; suite 454 passed (only the pre-existing DST test fails, green in UTC CI).
