### PR TITLE
feat: prettier notifications + actionable mobile acknowledge

### DIFF
--- a/config/config.yaml.example
+++ b/config/config.yaml.example
@@ -114,9 +114,10 @@ notifications:
   # is disabled — get told about stuck/offline entities without any reloads.
   on_issue_detected: false
 
-  # Mobile push: also send WARNING+ notifications to these notify entities via
-  # notify.send_message (e.g. the HA companion app). Empty = mobile disabled.
-  # Example: ["notify.jasons_iphone", "notify.melissas_iphone"]
+  # Mobile push: also send WARNING+ notifications to the HA companion app, with an
+  # "Acknowledge" action on long-press. Use the mobile_app notify SERVICES (which
+  # support action buttons), not the plain notify entities. Empty = mobile disabled.
+  # Example: ["notify.mobile_app_jasons_iphone", "notify.mobile_app_melissas_iphone"]
   mobile_push_services: []
 
   # Home Assistant notification service

--- a/ha_boss/core/types.py
+++ b/ha_boss/core/types.py
@@ -27,12 +27,14 @@ class HealthIssue:
         detected_at: datetime,
         details: dict[str, Any] | None = None,
         is_cloud: bool = False,
+        friendly_name: str | None = None,
     ):
         self.entity_id = entity_id
         self.issue_type = issue_type
         self.detected_at = detected_at
         self.details = details or {}
         self.is_cloud = is_cloud
+        self.friendly_name = friendly_name
 
     def __repr__(self) -> str:
         return (

--- a/ha_boss/healing/escalation.py
+++ b/ha_boss/healing/escalation.py
@@ -96,6 +96,7 @@ class NotificationEscalator:
             notification_type=NotificationType.ISSUE_DETECTED,
             severity=NotificationSeverity.WARNING,
             entity_id=health_issue.entity_id,
+            friendly_name=health_issue.friendly_name,
             issue_type=health_issue.issue_type,
             detected_at=health_issue.detected_at,
         )

--- a/ha_boss/monitoring/action_verifier.py
+++ b/ha_boss/monitoring/action_verifier.py
@@ -315,10 +315,12 @@ class ActionVerifier:
                 f"state {expected!r} (actual={actual!r}) after {self._av_cfg.delay_seconds}s"
             )
 
+            friendly_name = (state_data.get("attributes") or {}).get("friendly_name")
             context = NotificationContext(
                 notification_type=NotificationType.ACTION_VERIFICATION_FAILED,
                 severity=NotificationSeverity.WARNING,
                 entity_id=entity_id,
+                friendly_name=friendly_name,
                 extra={
                     "service": f"{domain}.{service}",
                     "expected_state": expected,

--- a/ha_boss/monitoring/health_monitor.py
+++ b/ha_boss/monitoring/health_monitor.py
@@ -243,6 +243,7 @@ class HealthMonitor:
                 "grace_period_seconds": self.config.monitoring.grace_period_seconds,
             },
             is_cloud=self._is_cloud(entity_id),
+            friendly_name=entity_state.attributes.get("friendly_name"),
         )
 
         # Persist to database
@@ -362,6 +363,7 @@ class HealthMonitor:
                 "last_updated": entity_state.last_updated.isoformat(),
             },
             is_cloud=self._is_cloud(entity_id),
+            friendly_name=entity_state.attributes.get("friendly_name"),
         )
 
 

--- a/ha_boss/monitoring/websocket_client.py
+++ b/ha_boss/monitoring/websocket_client.py
@@ -35,6 +35,7 @@ class WebSocketClient:
         entity_discovery: "EntityDiscoveryService | None" = None,
         on_state_changed: Callable[[dict[str, Any]], Coroutine[Any, Any, None]] | None = None,
         on_service_call: Callable[[dict[str, Any]], Coroutine[Any, Any, None]] | None = None,
+        on_notification_action: Callable[[dict[str, Any]], Coroutine[Any, Any, None]] | None = None,
     ) -> None:
         """Initialize WebSocket client.
 
@@ -46,6 +47,10 @@ class WebSocketClient:
             on_service_call: Optional async callback invoked for every call_service event
                 with the raw event data dict.  Called in addition to (not instead of)
                 the existing reload-trigger and automation-tracking logic.
+            on_notification_action: Optional async callback for
+                mobile_app_notification_action events (companion-app action taps),
+                receiving the event data dict. When set, the client also subscribes
+                to those events.
         """
         # Build WebSocket URL from HTTP URL
         ws_url = instance.url.replace("http://", "ws://").replace("https://", "wss://")
@@ -63,6 +68,7 @@ class WebSocketClient:
         # Callbacks
         self.on_state_changed = on_state_changed
         self.on_service_call = on_service_call
+        self.on_notification_action = on_notification_action
 
         # State
         self._ws: Any = None  # WebSocket connection
@@ -181,6 +187,13 @@ class WebSocketClient:
                 # Handle automation/scene/script reload events and track service calls
                 await self._handle_service_call(event.get("data", {}))
 
+            elif event_type == "mobile_app_notification_action" and self.on_notification_action:
+                # Companion-app notification action tap (e.g. "Acknowledge")
+                try:
+                    await self.on_notification_action(event.get("data", {}))
+                except Exception as e:
+                    logger.error(f"Error in on_notification_action callback: {e}", exc_info=True)
+
         elif msg_type == "pong":
             # Response to ping, ignore
             pass
@@ -282,6 +295,10 @@ class WebSocketClient:
                 if self.entity_discovery:
                     await self.subscribe_events("call_service")
 
+                # Subscribe to companion-app notification action taps (acknowledge)
+                if self.on_notification_action:
+                    await self.subscribe_events("mobile_app_notification_action")
+
                 logger.info("Reconnection successful")
 
                 # Restart listen loop
@@ -309,6 +326,10 @@ class WebSocketClient:
         # Also subscribe to call_service events for discovery refresh triggers
         if self.entity_discovery:
             await self.subscribe_events("call_service")
+
+        # Subscribe to companion-app notification action taps (acknowledge)
+        if self.on_notification_action:
+            await self.subscribe_events("mobile_app_notification_action")
 
         # Start listening loop
         asyncio.create_task(self._listen_loop())

--- a/ha_boss/notifications/manager.py
+++ b/ha_boss/notifications/manager.py
@@ -13,6 +13,10 @@ from ha_boss.notifications.templates import (
 
 logger = logging.getLogger(__name__)
 
+# Prefix for the mobile "Acknowledge" action; the notification_id is appended so
+# the action handler knows which notification to clear.
+_ACK_ACTION_PREFIX = "HABOSS_ACK::"
+
 
 class NotificationChannel(StrEnum):
     """Notification delivery channels."""
@@ -239,14 +243,17 @@ class NotificationManager:
         message: str,
         context: NotificationContext,
     ) -> None:
-        """Send notification as a mobile push via notify.send_message.
+        """Send notification as an actionable mobile push.
 
-        Sends to each configured notify entity (e.g. notify.jason_s_iphone).
-        Deduplicates per notification_id so a persistent issue pushes once.
+        Calls each configured mobile-app notify service (e.g.
+        ``notify.mobile_app_jason_s_iphone``) with a ``tag`` (so the push can be
+        cleared later) and an "Acknowledge" action that the companion app shows
+        on long-press. Deduplicates per notification_id so a persistent issue
+        pushes once.
 
         Args:
             title: Notification title
-            message: Notification message
+            message: Notification message (markdown; stripped to plain text here)
             context: Notification context
         """
         if self.ha_client is None:
@@ -268,13 +275,21 @@ class NotificationManager:
             logger.info(f"[DRY RUN] Would send mobile push to {services}: {title}")
             return
 
+        plain_message = self._strip_markdown(message)
+        data = {
+            "tag": notification_id,
+            "actions": [
+                {"action": f"{_ACK_ACTION_PREFIX}{notification_id}", "title": "Acknowledge"}
+            ],
+        }
+
         sent_any = False
         for service in services:
             try:
                 await self.ha_client.call_service(
                     "notify",
-                    "send_message",
-                    {"entity_id": service, "title": title, "message": message},
+                    self._notify_service_name(service),
+                    {"title": title, "message": plain_message, "data": data},
                 )
                 sent_any = True
             except Exception as e:
@@ -283,6 +298,54 @@ class NotificationManager:
         if sent_any:
             self._sent_mobile_notifications[notification_id] = context
             logger.info(f"Sent mobile push: {notification_id}")
+
+    @staticmethod
+    def _notify_service_name(configured: str) -> str:
+        """Map a configured value to a notify service name.
+
+        Accepts either ``notify.mobile_app_x`` or ``mobile_app_x`` and returns
+        the service part (``mobile_app_x``) for a legacy ``notify.<service>`` call,
+        which (unlike ``notify.send_message``) supports the ``data`` field needed
+        for actionable notifications.
+        """
+        return configured.split(".", 1)[-1]
+
+    @staticmethod
+    def _strip_markdown(text: str) -> str:
+        """Reduce markdown to plain text for mobile pushes (no literal ** or `)."""
+        return text.replace("**", "").replace("`", "")
+
+    async def _clear_mobile(self, notification_id: str) -> None:
+        """Clear a previously-sent mobile push by its tag on all services."""
+        if self.ha_client is None:
+            return
+        for service in self.config.notifications.mobile_push_services:
+            try:
+                await self.ha_client.call_service(
+                    "notify",
+                    self._notify_service_name(service),
+                    {"message": "clear_notification", "data": {"tag": notification_id}},
+                )
+            except Exception as e:
+                logger.debug(f"Failed to clear mobile push {notification_id} on {service}: {e}")
+
+    async def handle_notification_action(self, action: str) -> None:
+        """Handle a mobile_app_notification_action action string.
+
+        For our "Acknowledge" action, dismiss the matching HA persistent
+        notification and clear the mobile push. Non-HA-Boss actions are ignored.
+
+        Args:
+            action: The ``action`` field from a mobile_app_notification_action event.
+        """
+        if not action.startswith(_ACK_ACTION_PREFIX):
+            return
+        notification_id = action[len(_ACK_ACTION_PREFIX) :]
+        logger.info(f"Acknowledging notification from mobile: {notification_id}")
+        # dismiss() clears the HA persistent notification and re-arms the mobile
+        # dedup; _clear_mobile removes the push from the device.
+        await self.dismiss(notification_id)
+        await self._clear_mobile(notification_id)
 
     def notification_id_for(self, context: NotificationContext) -> str:
         """Return the notification ID that ``notify(context)`` would use.

--- a/ha_boss/notifications/templates.py
+++ b/ha_boss/notifications/templates.py
@@ -53,6 +53,7 @@ class NotificationContext:
     notification_type: NotificationType
     severity: NotificationSeverity
     entity_id: str | None = None
+    friendly_name: str | None = None
     integration_name: str | None = None
     integration_id: str | None = None
     issue_type: str | None = None
@@ -63,6 +64,40 @@ class NotificationContext:
     reset_time: datetime | None = None
     stats: dict[str, Any] | None = None
     extra: dict[str, Any] | None = None
+
+
+_SEVERITY_EMOJI: dict[NotificationSeverity, str] = {
+    NotificationSeverity.INFO: "ℹ️",
+    NotificationSeverity.WARNING: "⚠️",
+    NotificationSeverity.ERROR: "🛑",
+    NotificationSeverity.CRITICAL: "🚨",
+}
+
+# Human-readable phrasing for the common issue types.
+_ISSUE_PHRASING: dict[str, str] = {
+    "unavailable": "is unavailable",
+    "unknown": "is in an unknown state",
+    "stale": "stopped updating",
+}
+
+
+def display_name(context: NotificationContext) -> str:
+    """Return a human-friendly name for the entity in a notification.
+
+    Prefers the entity's ``friendly_name``; otherwise derives a readable name
+    from the entity_id (e.g. ``sensor.back_patio_motion`` -> "Back Patio Motion").
+    """
+    if context.friendly_name:
+        return context.friendly_name
+    if context.entity_id:
+        object_id = context.entity_id.split(".", 1)[-1]
+        return object_id.replace("_", " ").title()
+    return "Entity"
+
+
+def severity_emoji(severity: NotificationSeverity) -> str:
+    """Return the emoji for a severity level."""
+    return _SEVERITY_EMOJI.get(severity, "")
 
 
 class NotificationTemplate:
@@ -250,15 +285,12 @@ class RecoveryTemplate(NotificationTemplate):
         Returns:
             Tuple of (title, message)
         """
-        title = "HA Boss: Entity Recovered"
+        name = display_name(context)
+        title = f"✅ {name} recovered"
 
         lines = [
-            f"**Entity:** `{context.entity_id}`",
-            f"**Previous Issue:** {context.issue_type or 'Unknown'}",
-            "",
-            "The entity has recovered and is now reporting normally.",
-            "",
-            "No further action needed.",
+            f"**{name}** (`{context.entity_id}`)",
+            "Back to normal — no action needed.",
         ]
 
         message = "\n".join(lines)
@@ -278,22 +310,23 @@ class IssueDetectedTemplate(NotificationTemplate):
         Returns:
             Tuple of (title, message)
         """
-        title = "HA Boss: Entity Issue Detected"
+        name = display_name(context)
+        issue = context.issue_type or "unavailable"
+        phrasing = _ISSUE_PHRASING.get(issue, f"has an issue ({issue})")
+        title = f"{severity_emoji(context.severity)} {name} {phrasing}".strip()
 
-        lines = [
-            f"**Entity:** `{context.entity_id}`",
-            f"**Issue:** {context.issue_type or 'Unknown'}",
-        ]
+        lines = [f"**{name}** (`{context.entity_id}`)"]
 
         if context.detected_at:
             time_ago = IssueDetectedTemplate.format_time_ago(context.detected_at)
-            lines.append(f"**Detected:** {time_ago}")
+            lines.append(f"Status: **{issue}** since {time_ago}.")
+        else:
+            lines.append(f"Status: **{issue}**.")
 
         lines.extend(
             [
                 "",
-                "Auto-healing is disabled, so no automatic action was taken.",
-                "Please check the entity or its integration.",
+                "Long-press this notification to acknowledge it.",
             ]
         )
 
@@ -533,7 +566,7 @@ class OutOfScopeAuditTemplate(NotificationTemplate):
         Returns:
             Tuple of (title, message)
         """
-        title = "HA Boss: Out-of-Scope Audit"
+        title = "🗂️ HA Boss: Out-of-Scope Audit"
         stats = context.stats or {}
 
         new_failures: list[dict[str, Any]] = stats.get("new_failures", [])
@@ -606,23 +639,21 @@ class ActionVerificationFailedTemplate(NotificationTemplate):
         Returns:
             Tuple of (title, message)
         """
-        title = "HA Boss: Action Did Not Take Effect"
-
+        name = display_name(context)
         extra = context.extra or {}
         service = extra.get("service", "unknown service")
         expected_state = extra.get("expected_state", "unknown")
         actual_state = extra.get("actual_state", "unknown")
         delay_seconds = extra.get("delay_seconds", 0)
 
+        title = f"{severity_emoji(context.severity)} {name} didn't respond".strip()
+
         lines = [
-            f"**Entity:** `{context.entity_id}`",
-            f"**Service Called:** `{service}`",
-            f"**Expected State:** `{expected_state}`",
-            f"**Actual State:** `{actual_state}`",
-            f"**Check Delay:** {delay_seconds}s",
+            f"**{name}** (`{context.entity_id}`)",
+            f"`{service}` expected **{expected_state}** but it's still **{actual_state}** "
+            f"after {delay_seconds}s.",
             "",
-            "The entity did not reach the expected state after the service call.",
-            "Please check the device or integration for issues.",
+            "Long-press this notification to acknowledge it.",
         ]
 
         message = "\n".join(lines)

--- a/ha_boss/service/main.py
+++ b/ha_boss/service/main.py
@@ -344,6 +344,13 @@ class HABossService:
         # 10. Connect WebSocket
         logger.info(f"[{instance_id}] Connecting to Home Assistant WebSocket...")
         action_verifier = self.action_verifiers.get(instance_id)
+        # Only handle notification actions when mobile push is configured (the
+        # acknowledge action arrives via the companion app).
+        on_notification_action = (
+            (lambda data: self._on_notification_action(instance_id, data))
+            if self.config.notifications.mobile_push_services
+            else None
+        )
         self.websocket_clients[instance_id] = WebSocketClient(
             instance=instance,
             config=self.config,
@@ -352,6 +359,7 @@ class HABossService:
             on_service_call=(
                 action_verifier.handle_service_call if action_verifier is not None else None
             ),
+            on_notification_action=on_notification_action,
         )
         await self.websocket_clients[instance_id].start()
 
@@ -562,6 +570,24 @@ class HABossService:
             logger.error(
                 f"[{instance_id}] Error handling WebSocket state change: {e}", exc_info=True
             )
+
+    async def _on_notification_action(self, instance_id: str, data: dict[str, Any]) -> None:
+        """Handle a mobile_app_notification_action event (e.g. acknowledge tap).
+
+        Args:
+            instance_id: Home Assistant instance identifier
+            data: Event data; its ``action`` field identifies the tapped action.
+        """
+        action = data.get("action", "")
+        manager = self.notification_managers.get(instance_id)
+        if manager and action:
+            try:
+                await manager.handle_notification_action(action)
+            except Exception as e:
+                logger.error(
+                    f"[{instance_id}] Error handling notification action {action!r}: {e}",
+                    exc_info=True,
+                )
 
     async def _on_state_updated(
         self, instance_id: str, new_state: EntityState, old_state: EntityState | None

--- a/tests/healing/test_escalation.py
+++ b/tests/healing/test_escalation.py
@@ -202,7 +202,7 @@ async def test_notify_recovery(escalator, mock_ha_client, caplog):
         await escalator.notify_recovery("sensor.test_sensor", "unavailable")
 
     # Verify the notification was processed (logged to CLI)
-    assert "Entity Recovered" in caplog.text
+    assert "recovered" in caplog.text.lower()
     assert "sensor.test_sensor" in caplog.text
 
 
@@ -345,7 +345,7 @@ async def test_notify_issue_detected_enabled(
 
     mock_ha_client.create_persistent_notification.assert_called_once()
     call_args = mock_ha_client.create_persistent_notification.call_args
-    assert call_args.kwargs["title"] == "HA Boss: Entity Issue Detected"
+    assert "unavailable" in call_args.kwargs["title"]
     assert "sensor.test_sensor" in call_args.kwargs["message"]
     assert "unavailable" in call_args.kwargs["message"]
 

--- a/tests/monitoring/test_websocket_client.py
+++ b/tests/monitoring/test_websocket_client.py
@@ -237,6 +237,31 @@ async def test_handle_state_changed_event(ws_client):
 
 
 @pytest.mark.asyncio
+async def test_handle_notification_action_event(ws_client):
+    """mobile_app_notification_action events route to on_notification_action."""
+    received = None
+
+    async def on_action(data):
+        nonlocal received
+        received = data
+
+    ws_client.on_notification_action = on_action
+
+    event_message = {
+        "type": "event",
+        "event": {
+            "event_type": "mobile_app_notification_action",
+            "data": {"action": "HABOSS_ACK::haboss_issue_detected_sensor_x"},
+        },
+    }
+
+    await ws_client._handle_message(event_message)
+
+    assert received is not None
+    assert received["action"] == "HABOSS_ACK::haboss_issue_detected_sensor_x"
+
+
+@pytest.mark.asyncio
 async def test_handle_pong_message(ws_client):
     """Test handling pong message."""
     # Pong messages should be silently ignored

--- a/tests/notifications/test_manager.py
+++ b/tests/notifications/test_manager.py
@@ -503,11 +503,20 @@ class TestMobilePush:
         manager = NotificationManager(_mobile_config([]), mock_ha_client)
         assert manager._channels[NotificationChannel.MOBILE] is False
 
+    @staticmethod
+    def _mobile_pushes(mock_ha_client: AsyncMock) -> list:
+        """Mobile push send calls (notify.<service> with an actions payload)."""
+        return [
+            c
+            for c in mock_ha_client.call_service.call_args_list
+            if c.args[0] == "notify" and "actions" in (c.args[2].get("data") or {})
+        ]
+
     @pytest.mark.asyncio
     async def test_warning_pushes_to_each_service(self, mock_ha_client: AsyncMock) -> None:
-        """A WARNING notification pushes to every configured notify entity."""
+        """A WARNING notification pushes to every configured mobile-app service."""
         manager = NotificationManager(
-            _mobile_config(["notify.jason_s_iphone", "notify.melissas_iphone"]), mock_ha_client
+            _mobile_config(["notify.mobile_app_jason", "notify.mobile_app_mel"]), mock_ha_client
         )
         context = NotificationContext(
             notification_type=NotificationType.ISSUE_DETECTED,
@@ -518,22 +527,22 @@ class TestMobilePush:
 
         await manager.notify(context)
 
-        pushes = [
-            c
-            for c in mock_ha_client.call_service.call_args_list
-            if c.args[:2] == ("notify", "send_message")
-        ]
+        pushes = self._mobile_pushes(mock_ha_client)
         assert len(pushes) == 2
-        assert {c.args[2]["entity_id"] for c in pushes} == {
-            "notify.jason_s_iphone",
-            "notify.melissas_iphone",
-        }
+        # The "notify." prefix is stripped to call the legacy service.
+        assert {c.args[1] for c in pushes} == {"mobile_app_jason", "mobile_app_mel"}
         assert all("back_patio_motion" in c.args[2]["message"] for c in pushes)
+        # Actionable: an Acknowledge action + a tag are attached.
+        for c in pushes:
+            data = c.args[2]["data"]
+            assert data["tag"]
+            assert data["actions"][0]["title"] == "Acknowledge"
+            assert data["actions"][0]["action"].startswith("HABOSS_ACK::")
 
     @pytest.mark.asyncio
     async def test_mobile_push_deduplicated(self, mock_ha_client: AsyncMock) -> None:
         """Repeated detections of the same issue push only once."""
-        manager = NotificationManager(_mobile_config(["notify.jason_s_iphone"]), mock_ha_client)
+        manager = NotificationManager(_mobile_config(["notify.mobile_app_jason"]), mock_ha_client)
         context = NotificationContext(
             notification_type=NotificationType.ISSUE_DETECTED,
             severity=NotificationSeverity.WARNING,
@@ -545,16 +554,12 @@ class TestMobilePush:
         mock_ha_client.call_service.reset_mock()
         await manager.notify(context)
 
-        assert not [
-            c
-            for c in mock_ha_client.call_service.call_args_list
-            if c.args[:2] == ("notify", "send_message")
-        ]
+        assert not self._mobile_pushes(mock_ha_client)
 
     @pytest.mark.asyncio
     async def test_info_severity_does_not_push(self, mock_ha_client: AsyncMock) -> None:
         """INFO-level notifications (e.g. recovery) do not push to mobile."""
-        manager = NotificationManager(_mobile_config(["notify.jason_s_iphone"]), mock_ha_client)
+        manager = NotificationManager(_mobile_config(["notify.mobile_app_jason"]), mock_ha_client)
         context = NotificationContext(
             notification_type=NotificationType.RECOVERY,
             severity=NotificationSeverity.INFO,
@@ -563,8 +568,43 @@ class TestMobilePush:
 
         await manager.notify(context)
 
-        assert not [
+        assert not self._mobile_pushes(mock_ha_client)
+
+    @pytest.mark.asyncio
+    async def test_acknowledge_action_dismisses_and_clears(self, mock_ha_client: AsyncMock) -> None:
+        """Handling an Acknowledge action dismisses the HA notif and clears the push."""
+        manager = NotificationManager(_mobile_config(["notify.mobile_app_jason"]), mock_ha_client)
+        context = NotificationContext(
+            notification_type=NotificationType.ISSUE_DETECTED,
+            severity=NotificationSeverity.WARNING,
+            entity_id="binary_sensor.back_patio_motion",
+            issue_type="unavailable",
+        )
+        await manager.notify(context)
+        notification_id = manager.notification_id_for(context)
+        mock_ha_client.call_service.reset_mock()
+        mock_ha_client.call_service.return_value = None
+
+        await manager.handle_notification_action(f"HABOSS_ACK::{notification_id}")
+
+        # Dismissed the HA persistent notification
+        dismisses = [
             c
             for c in mock_ha_client.call_service.call_args_list
-            if c.args[:2] == ("notify", "send_message")
+            if c.args[:2] == ("persistent_notification", "dismiss")
         ]
+        assert dismisses and dismisses[0].args[2]["notification_id"] == notification_id
+        # Cleared the mobile push by tag
+        clears = [
+            c
+            for c in mock_ha_client.call_service.call_args_list
+            if c.args[0] == "notify" and c.args[2].get("message") == "clear_notification"
+        ]
+        assert clears and clears[0].args[2]["data"]["tag"] == notification_id
+
+    @pytest.mark.asyncio
+    async def test_unknown_action_ignored(self, mock_ha_client: AsyncMock) -> None:
+        """A non-HA-Boss action string is ignored."""
+        manager = NotificationManager(_mobile_config(["notify.mobile_app_jason"]), mock_ha_client)
+        await manager.handle_notification_action("SOME_OTHER_APP_ACTION")
+        mock_ha_client.call_service.assert_not_called()

--- a/tests/notifications/test_templates.py
+++ b/tests/notifications/test_templates.py
@@ -203,10 +203,9 @@ class TestRecoveryTemplate:
 
         title, message = RecoveryTemplate.render(context)
 
-        assert title == "HA Boss: Entity Recovered"
+        assert "recovered" in title.lower()
+        assert "Temperature" in title
         assert "sensor.temperature" in message
-        assert "unavailable" in message
-        assert "recovered" in message.lower()
 
 
 class TestIssueDetectedTemplate:
@@ -224,12 +223,12 @@ class TestIssueDetectedTemplate:
 
         title, message = IssueDetectedTemplate.render(context)
 
-        assert title == "HA Boss: Entity Issue Detected"
+        # Friendly derived name + state in the title
+        assert "Back Patio Motion" in title
+        assert "unavailable" in title
         assert "binary_sensor.back_patio_motion" in message
-        assert "unavailable" in message
         assert "5 minutes ago" in message
-        # Must make clear no automatic action was taken
-        assert "no automatic action" in message.lower()
+        assert "acknowledge" in message.lower()
 
     def test_render_minimal(self) -> None:
         """Test rendering without optional detected_at."""
@@ -241,9 +240,9 @@ class TestIssueDetectedTemplate:
 
         title, message = IssueDetectedTemplate.render(context)
 
-        assert title == "HA Boss: Entity Issue Detected"
         assert "sensor.test" in message
-        assert "Unknown" in message
+        # issue_type defaults to unavailable
+        assert "unavailable" in title.lower()
 
 
 class TestCircuitBreakerTemplate:
@@ -417,7 +416,7 @@ class TestTemplateRegistry:
 
         title, message = TemplateRegistry.render(context)
 
-        assert title == "HA Boss: Entity Recovered"
+        assert "recovered" in title.lower()
 
     def test_render_issue_detected(self) -> None:
         """Test registry renders issue detected correctly."""
@@ -430,7 +429,7 @@ class TestTemplateRegistry:
 
         title, message = TemplateRegistry.render(context)
 
-        assert title == "HA Boss: Entity Issue Detected"
+        assert title  # pretty title with friendly name + state
         assert "sensor.test" in message
 
     def test_render_circuit_breaker(self) -> None:
@@ -484,7 +483,7 @@ class TestTemplateRegistry:
 
         title, message = TemplateRegistry.render(context)
 
-        assert title == "HA Boss: Out-of-Scope Audit"
+        assert "Out-of-Scope Audit" in title
         assert "light.garage" in message
         assert "hue" in message
         assert "2 chronic" in message
@@ -518,7 +517,7 @@ class TestOutOfScopeAuditTemplate:
 
         title, message = OutOfScopeAuditTemplate.render(context)
 
-        assert title == "HA Boss: Out-of-Scope Audit"
+        assert "Out-of-Scope Audit" in title
         assert "sensor.garage_temp" in message
         assert "light.porch" in message
         assert "zigbee2mqtt" in message
@@ -595,7 +594,7 @@ class TestOutOfScopeAuditTemplate:
 
         title, message = OutOfScopeAuditTemplate.render(context)
 
-        assert title == "HA Boss: Out-of-Scope Audit"
+        assert "Out-of-Scope Audit" in title
         # Should not crash; returns a sensible default
         assert message
 
@@ -624,10 +623,11 @@ class TestActionVerificationFailedTemplate:
         )
 
     def test_title(self) -> None:
-        """Template title is 'HA Boss: Action Did Not Take Effect'."""
+        """Template title carries the friendly name and a 'didn't respond' phrasing."""
         context = self._make_context()
         title, _ = ActionVerificationFailedTemplate.render(context)
-        assert title == "HA Boss: Action Did Not Take Effect"
+        assert "Bedroom" in title
+        assert "respond" in title.lower()
 
     def test_body_contains_entity_id(self) -> None:
         """Rendered body contains the target entity ID."""
@@ -663,7 +663,7 @@ class TestActionVerificationFailedTemplate:
             extra=None,
         )
         title, message = ActionVerificationFailedTemplate.render(context)
-        assert title == "HA Boss: Action Did Not Take Effect"
+        assert "Bedroom" in title
         assert message  # Should not crash
 
     def test_registered_in_template_registry(self) -> None:
@@ -680,5 +680,5 @@ class TestActionVerificationFailedTemplate:
             },
         )
         title, message = TemplateRegistry.render(context)
-        assert title == "HA Boss: Action Did Not Take Effect"
+        assert title  # pretty title
         assert "light.bedroom" in message


### PR DESCRIPTION
Notification UX overhaul for the monitor-and-notify alerts.

**Prettier messages**
- Titles lead with a severity emoji + the entity's friendly name and state — e.g. `⚠️ Back Patio Motion is unavailable` instead of `HA Boss: Entity Issue Detected`. `friendly_name` is plumbed from the monitor's cached state (and the action verifier's fetched state) through `HealthIssue`/`NotificationContext`, with a fallback that derives a readable name from the entity_id.
- Bodies rewritten to be concise and accurate (dropped the stale "auto-healing disabled" text). Mobile pushes get plain text (markdown stripped) so there's no literal `**`/`` ` ``.

**Actionable mobile push (long-press → Acknowledge)**
- Mobile pushes now go via the `notify.mobile_app_*` services (which support a `data` payload) instead of `notify.send_message` (which can't carry actions), with a `tag` and an "Acknowledge" action.
- `WebSocketClient` subscribes to `mobile_app_notification_action` events (when a callback is wired) and dispatches them.
- `NotificationManager.handle_notification_action()` clears the HA persistent notification **and** the mobile push when Acknowledge is tapped. Recovery stays silent (clears the alert, no new push).
- **Config:** `mobile_push_services` should now be the `mobile_app_*` services (e.g. `notify.mobile_app_jason_s_iphone`).

Net: 13 files. +tests for templates, mobile payload/actions, the ack handler, and the action event dispatch. mypy 0; black/ruff clean; full suite green (only the pre-existing DST test fails, green in UTC CI).

> Note: the live `mobile_push_services` value will be updated to `notify.mobile_app_jason_s_iphone` at deploy. The actual long-press round-trip is best verified on the phone after deploy.
