### PR TITLE
fix: infinite WS reconnect, connection-lost alert, accurate config/CLI

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,128 +1,106 @@
 # HA Boss Configuration
-# Copy to config.yaml and customize for your setup
+# Monitor-and-notify watchdog for Home Assistant.
+# Scopes itself to entities referenced in your automations/scenes/scripts
+# and notifies you when one goes unavailable, unknown, or stale.
+# No healing, no AI, no REST API — just monitoring and alerts.
 
 home_assistant:
-  # Home Assistant instance URL (uses HA_URL environment variable)
+  # Home Assistant URL (set HA_URL env var, or replace the placeholder)
   url: "${HA_URL}"
 
-  # Long-lived access token (uses HA_TOKEN environment variable)
-  # Create at: http://your-ha/profile -> Long-Lived Access Tokens
+  # Long-lived access token (set HA_TOKEN env var, or replace the placeholder)
+  # Create one at: http://your-ha/profile -> Long-Lived Access Tokens
   token: "${HA_TOKEN}"
 
 monitoring:
-  # Entities to monitor (glob patterns, empty list = all entities)
-  include: []
+  # Grace period before an unavailable/unknown entity triggers an alert (seconds)
+  grace_period_seconds: 300  # 5 minutes
 
-  # Entities to exclude from monitoring
+  # Entities whose state has not changed in this long are flagged as stale (seconds)
+  stale_threshold_seconds: 3600  # 1 hour
+
+  # Patterns always excluded from monitoring (fnmatch syntax)
   exclude:
     - "sensor.time*"
     - "sensor.date*"
     - "sensor.uptime*"
     - "sun.sun"
 
-  # Grace period before considering entity truly unavailable (seconds)
-  grace_period_seconds: 300  # 5 minutes
+  # Entities for which "unavailable" is their normal powered-off state (e.g. TVs).
+  # Matching entities are never flagged, and a turn_off that leaves them unavailable
+  # is treated as success by the action verifier.
+  unavailable_ok: []
+  # Example:
+  #   - "media_player.lg_webos_tv_*"
 
-  # Threshold for stale entities (no update in X seconds)
-  stale_threshold_seconds: 3600  # 1 hour
+  # Auto-discovery: scope monitoring to entities used in automations/scenes/scripts.
+  # Leave include: [] empty (discovery handles scoping automatically).
+  include: []
+  auto_discovery:
+    enabled: true
+    refresh_interval_seconds: 3600  # Re-scan every hour
 
-  # Periodic REST API snapshot interval (seconds)
-  # Used to validate WebSocket cache
-  snapshot_interval_seconds: 300  # 5 minutes
+  # Cloud integration handling: entities backed by internet APIs (PSN, Plex, Life360)
+  # get a longer grace period and no mobile push, since you can't fix their outages.
+  cloud_handling:
+    enabled: true
+    grace_period_seconds: 900   # 15 minutes for cloud entities
+    suppress_mobile_push: true  # HA persistent + CLI still fire
 
-healing:
-  # Enable auto-healing
-  enabled: true
+  # Action verification: warn if a service call doesn't take effect within delay_seconds.
+  # Useful for catching unresponsive lights/switches.
+  action_verification:
+    enabled: false
+    delay_seconds: 30
 
-  # Maximum healing attempts per integration
-  max_attempts: 3
-
-  # Cooldown between healing attempts (seconds)
-  cooldown_seconds: 300  # 5 minutes
-
-  # Circuit breaker threshold (stop trying after N total failures)
-  circuit_breaker_threshold: 10
-
-  # Circuit breaker reset time (seconds)
-  # After this time with no failures, reset counter
-  circuit_breaker_reset_seconds: 3600  # 1 hour
+  # Out-of-scope audit: periodic digest of unavailable entities outside your monitored set.
+  # Surfaces broken integrations (Plex, PSN, OctoPrint) without spamming alerts for them.
+  out_of_scope_audit:
+    enabled: false
+    interval_seconds: 86400   # Once per day
 
 notifications:
-  # Send notifications when auto-healing fails
-  on_healing_failure: true
+  # Send an alert when a monitored entity goes unavailable/unknown/stale.
+  # This is the core function of HA Boss — leave it enabled.
+  on_issue_detected: true
 
-  # Send weekly summary reports
-  weekly_summary: true
-
-  # Home Assistant notification service
+  # Home Assistant notification service (persistent notifications in the UI)
   ha_service: "persistent_notification.create"
 
-  # Optional: Email notifications
-  # email:
-  #   enabled: false
-  #   smtp_server: "smtp.gmail.com"
-  #   smtp_port: 587
-  #   username: "your-email@gmail.com"
-  #   password: "${EMAIL_PASSWORD}"
-  #   from: "haboss@example.com"
-  #   to: "your-email@gmail.com"
+  # Mobile push via the HA Companion app. Add your notify service(s) here.
+  # Must use the mobile_app variant (e.g. notify.mobile_app_your_phone) to
+  # support actionable "Acknowledge" button on long-press.
+  mobile_push_services: []
+  # Example:
+  #   - "notify.mobile_app_jason_s_iphone"
 
-# Operational mode
-# - production: Full auto-healing enabled
-# - dry_run: Log actions but don't execute
-# - testing: Use test HA instance
+# Operational mode: production | dry_run | testing
+# - production: sends real notifications
+# - dry_run:    logs what would be sent, no real notifications
 mode: "production"
 
-# Logging configuration
 logging:
-  level: "INFO"  # DEBUG, INFO, WARNING, ERROR, CRITICAL
-  format: "json"  # json or text
-  file: "data/ha_boss.log"
+  level: "INFO"   # DEBUG | INFO | WARNING | ERROR | CRITICAL
+  format: "text"  # text | json
+  file: "/data/ha_boss.log"
   max_size_mb: 10
   backup_count: 5
 
-# Database configuration
 database:
-  # SQLite database path
-  path: "data/ha_boss.db"
-
-  # Enable SQL query logging (debug only)
+  path: "/data/ha_boss.db"
   echo: false
-
-  # History retention (days)
-  # Older records are automatically purged
   retention_days: 30
 
-# WebSocket configuration
 websocket:
-  # Reconnect delay (seconds)
   reconnect_delay_seconds: 5
-
-  # Heartbeat interval (seconds)
-  # Send ping every N seconds to keep connection alive
   heartbeat_interval_seconds: 30
-
-  # Connection timeout (seconds)
   timeout_seconds: 10
+  # Maximum per-attempt delay during reconnect backoff (seconds)
+  max_reconnect_delay_seconds: 300
+  # Send a CONNECTION_ERROR notification after being disconnected this long (seconds)
+  reconnect_notify_after_seconds: 1800  # 30 minutes
 
-# REST API configuration
 rest:
-  # Request timeout (seconds)
   timeout_seconds: 10
-
-  # Retry attempts for failed requests
   retry_attempts: 3
-
-  # Base delay for exponential backoff (seconds)
   retry_base_delay_seconds: 1.0
-
-# REST API server configuration
-api:
-  enabled: true
-  host: "0.0.0.0"
-  port: 8000
-  cors_enabled: true
-  cors_origins:
-    - "*"
-  auth_enabled: false
-  api_keys: []

--- a/ha_boss/cli/commands.py
+++ b/ha_boss/cli/commands.py
@@ -396,9 +396,7 @@ async def _show_db_stats(config: Config) -> None:
 
                 cutoff_7d = datetime.now(UTC) - timedelta(days=7)
 
-                total_events = await session.scalar(
-                    select(func.count()).select_from(HealthEvent)
-                )
+                total_events = await session.scalar(select(func.count()).select_from(HealthEvent))
                 issues_7d = await session.scalar(
                     select(func.count())
                     .select_from(HealthEvent)

--- a/ha_boss/cli/commands.py
+++ b/ha_boss/cli/commands.py
@@ -137,28 +137,32 @@ def init(
         console.print("[dim]Use --force to overwrite[/dim]")
     else:
         config_template = """# HA Boss Configuration
+# Monitor-and-notify watchdog for Home Assistant.
 
 home_assistant:
-  url: ${HA_URL}  # e.g., http://homeassistant.local:8123
-  token: ${HA_TOKEN}  # Long-lived access token from HA
+  url: ${HA_URL}   # e.g., http://homeassistant.local:8123
+  token: ${HA_TOKEN}  # Long-lived access token from HA profile
 
 monitoring:
-  grace_period_seconds: 300  # Wait before marking entity as unavailable
-  stale_threshold_seconds: 3600  # Threshold for stale entities
+  grace_period_seconds: 300   # Wait before alerting on unavailable entity (5 min)
+  stale_threshold_seconds: 3600  # Alert if no state update within this window (1 hr)
   exclude:
     - "sensor.time*"
     - "sensor.date*"
+    - "sensor.uptime*"
     - "sun.sun"
-
-healing:
-  enabled: true
-  max_attempts: 3
-  cooldown_seconds: 300
-  circuit_breaker_threshold: 10
+  # Entities where "unavailable" is normal (e.g. a TV that's off). Never alerted.
+  unavailable_ok: []
 
 notifications:
-  on_healing_failure: true
-  weekly_summary: true
+  on_issue_detected: true  # Core feature — alert when a monitored entity goes bad
+  ha_service: "persistent_notification.create"
+  # Add your HA Companion app notify service(s) for mobile push:
+  mobile_push_services: []
+  # - "notify.mobile_app_your_phone"
+
+# production = real notifications; dry_run = log only
+mode: production
 
 logging:
   level: INFO
@@ -167,16 +171,6 @@ logging:
 database:
   path: data/ha_boss.db
   retention_days: 30
-
-intelligence:
-  pattern_collection_enabled: true  # Enable pattern collection for reliability analysis
-
-api:
-  enabled: true  # Enable REST API server for health checks
-  host: 0.0.0.0
-  port: 8000
-
-mode: production  # production, dry_run, or testing
 """
         config_file.write_text(config_template)
         console.print(f"\n[green]✓[/green] Created configuration: {config_file}")
@@ -248,9 +242,9 @@ def start(
 
     This command starts the main monitoring loop that:
     - Connects to Home Assistant via WebSocket
-    - Monitors entity health in real-time
-    - Automatically heals failed integrations
-    - Sends notifications when manual intervention is needed
+    - Scopes monitoring to entities referenced in your automations/scenes/scripts
+    - Detects unavailable, unknown, and stale entities
+    - Sends notifications via HA persistent notifications and optional mobile push
     """
     console.print(
         Panel.fit(
@@ -395,38 +389,40 @@ async def _show_db_stats(config: Config) -> None:
     """
     try:
         async with Database(str(config.database.path)) as db:
-            # Get statistics from database
             async with db.async_session() as session:
                 from sqlalchemy import func, select
 
-                from ha_boss.core.database import Entity, HealingAction, HealthEvent
+                from ha_boss.core.database import HealthEvent
 
-                # Count records
-                entity_count = await session.scalar(select(func.count()).select_from(Entity))
-                health_count = await session.scalar(select(func.count()).select_from(HealthEvent))
-                healing_count = await session.scalar(
-                    select(func.count()).select_from(HealingAction)
+                cutoff_7d = datetime.now(UTC) - timedelta(days=7)
+
+                total_events = await session.scalar(
+                    select(func.count()).select_from(HealthEvent)
                 )
-
-                # Count successful healings
-                successful_healings = await session.scalar(
+                issues_7d = await session.scalar(
                     select(func.count())
-                    .select_from(HealingAction)
-                    .where(HealingAction.success == True)  # noqa: E712
+                    .select_from(HealthEvent)
+                    .where(
+                        HealthEvent.timestamp >= cutoff_7d,
+                        HealthEvent.event_type != "recovered",
+                    )
+                )
+                recoveries_7d = await session.scalar(
+                    select(func.count())
+                    .select_from(HealthEvent)
+                    .where(
+                        HealthEvent.timestamp >= cutoff_7d,
+                        HealthEvent.event_type == "recovered",
+                    )
                 )
 
                 table = Table(show_header=False)
                 table.add_column("Metric", style="cyan")
-                table.add_column("Count", justify="right")
+                table.add_column("Value", justify="right")
 
-                table.add_row("Tracked Entities", str(entity_count or 0))
-                table.add_row("Health Events", str(health_count or 0))
-                table.add_row("Healing Attempts", str(healing_count or 0))
-                table.add_row("Successful Healings", str(successful_healings or 0))
-
-                if healing_count and healing_count > 0:
-                    success_rate = (successful_healings or 0) / healing_count * 100
-                    table.add_row("Success Rate", f"{success_rate:.1f}%")
+                table.add_row("Issues Detected (7d)", str(issues_7d or 0))
+                table.add_row("Recoveries (7d)", str(recoveries_7d or 0))
+                table.add_row("Total Health Events", str(total_events or 0))
 
                 console.print("\n", table)
 

--- a/ha_boss/core/config.py
+++ b/ha_boss/core/config.py
@@ -388,7 +388,7 @@ class NotificationsConfig(BaseSettings):
         description="Notify when healing fails",
     )
     on_issue_detected: bool = Field(
-        default=False,
+        default=True,
         description=(
             "Notify when an issue is detected even if auto-healing is disabled "
             "(monitor-and-notify mode)"
@@ -477,6 +477,19 @@ class WebSocketConfig(BaseSettings):
         default=10,
         description="Connection timeout",
         ge=5,
+    )
+    max_reconnect_delay_seconds: int = Field(
+        default=300,
+        description="Maximum delay between reconnect attempts (exponential backoff cap)",
+        ge=5,
+    )
+    reconnect_notify_after_seconds: int = Field(
+        default=1800,
+        description=(
+            "Fire the on_connect_lost notification callback after being disconnected "
+            "for this many seconds (default: 30 minutes)"
+        ),
+        ge=60,
     )
 
 

--- a/ha_boss/healing/escalation.py
+++ b/ha_boss/healing/escalation.py
@@ -143,6 +143,23 @@ class NotificationEscalator:
         await self.notification_manager.notify(context)
         logger.info(f"Sent recovery notification for {entity_id}")
 
+    async def notify_connection_error(self, error: str | None = None) -> None:
+        """Send notification about a persistent WebSocket connection failure.
+
+        Fired when the WebSocket has been disconnected for longer than
+        config.websocket.reconnect_notify_after_seconds.
+
+        Args:
+            error: Optional description of the connection error.
+        """
+        context = NotificationContext(
+            notification_type=NotificationType.CONNECTION_ERROR,
+            severity=NotificationSeverity.ERROR,
+            error=error,
+        )
+        await self.notification_manager.notify(context)
+        logger.info("Sent connection-error notification")
+
     async def dismiss_issue_detected(self, entity_id: str) -> None:
         """Clear a prior issue-detected notification without sending a recovery alert.
 

--- a/ha_boss/monitoring/websocket_client.py
+++ b/ha_boss/monitoring/websocket_client.py
@@ -4,6 +4,7 @@ import asyncio
 import json
 import logging
 from collections.abc import Callable, Coroutine
+from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
 import websockets
@@ -36,6 +37,7 @@ class WebSocketClient:
         on_state_changed: Callable[[dict[str, Any]], Coroutine[Any, Any, None]] | None = None,
         on_service_call: Callable[[dict[str, Any]], Coroutine[Any, Any, None]] | None = None,
         on_notification_action: Callable[[dict[str, Any]], Coroutine[Any, Any, None]] | None = None,
+        on_connect_lost: Callable[[], Coroutine[Any, Any, None]] | None = None,
     ) -> None:
         """Initialize WebSocket client.
 
@@ -51,6 +53,9 @@ class WebSocketClient:
                 mobile_app_notification_action events (companion-app action taps),
                 receiving the event data dict. When set, the client also subscribes
                 to those events.
+            on_connect_lost: Optional async callback fired once when the connection has
+                been lost for longer than config.websocket.reconnect_notify_after_seconds.
+                Cleared on successful reconnect.
         """
         # Build WebSocket URL from HTTP URL
         ws_url = instance.url.replace("http://", "ws://").replace("https://", "wss://")
@@ -69,12 +74,16 @@ class WebSocketClient:
         self.on_state_changed = on_state_changed
         self.on_service_call = on_service_call
         self.on_notification_action = on_notification_action
+        self.on_connect_lost = on_connect_lost
 
         # State
         self._ws: Any = None  # WebSocket connection
         self._message_id = 0
         self._running = False
         self._reconnect_task: asyncio.Task[None] | None = None
+        # Reconnect tracking for lost-connection notification
+        self._reconnect_started_at: datetime | None = None
+        self._reconnect_notified: bool = False
 
     def _next_id(self) -> int:
         """Get next message ID for requests."""
@@ -276,41 +285,59 @@ class WebSocketClient:
                     self._reconnect_task = asyncio.create_task(self._reconnect())
 
     async def _reconnect(self) -> None:
-        """Reconnect with exponential backoff."""
-        attempt = 0
-        while self._running and attempt < self.max_retries:
-            attempt += 1
-            delay = self.retry_base_delay * (2 ** (attempt - 1))
+        """Reconnect with infinite exponential backoff (capped at max_reconnect_delay_seconds).
 
-            logger.info(
-                f"Attempting to reconnect (attempt {attempt}/{self.max_retries}) " f"in {delay}s..."
+        Runs until the connection is re-established or stop() sets _running=False.
+        Fires on_connect_lost once after reconnect_notify_after_seconds of continuous
+        disconnection so the user is alerted to a persistent outage.
+        """
+        attempt = 0
+        self._reconnect_started_at = datetime.now(UTC)
+        self._reconnect_notified = False
+
+        while self._running:
+            attempt += 1
+            delay = min(
+                self.retry_base_delay * (2 ** (attempt - 1)),
+                self.config.websocket.max_reconnect_delay_seconds,
             )
+            logger.info(f"Attempting to reconnect (attempt {attempt}) in {delay:.0f}s...")
             await asyncio.sleep(delay)
+
+            if not self._running:
+                break
+
+            # Fire lost-connection notification once after threshold has elapsed
+            if not self._reconnect_notified and self.on_connect_lost is not None:
+                elapsed = (datetime.now(UTC) - self._reconnect_started_at).total_seconds()
+                if elapsed >= self.config.websocket.reconnect_notify_after_seconds:
+                    try:
+                        await self.on_connect_lost()
+                    except Exception as e:
+                        logger.error(f"Error in on_connect_lost callback: {e}", exc_info=True)
+                    self._reconnect_notified = True
 
             try:
                 await self.connect()
-                await self.subscribe_events()  # Subscribe to state_changed
-
-                # Also subscribe to call_service events for discovery refresh triggers
-                if self.entity_discovery:
-                    await self.subscribe_events("call_service")
-
-                # Subscribe to companion-app notification action taps (acknowledge)
-                if self.on_notification_action:
-                    await self.subscribe_events("mobile_app_notification_action")
-
+                await self._resubscribe()
                 logger.info("Reconnection successful")
-
-                # Restart listen loop
+                self._reconnect_started_at = None
+                self._reconnect_notified = False
                 asyncio.create_task(self._listen_loop())
                 return
 
             except Exception as e:
                 logger.error(f"Reconnection attempt {attempt} failed: {e}")
 
-        if self._running:
-            logger.error("Failed to reconnect after all retry attempts")
-            self._running = False
+    async def _resubscribe(self) -> None:
+        """Re-subscribe to all required event types after (re)connect."""
+        await self.subscribe_events()  # state_changed (always)
+        # call_service: needed for discovery refresh triggers and action verification
+        if self.entity_discovery or self.on_service_call:
+            await self.subscribe_events("call_service")
+        # companion-app notification action taps (acknowledge)
+        if self.on_notification_action:
+            await self.subscribe_events("mobile_app_notification_action")
 
     async def start(self) -> None:
         """Start WebSocket client and begin listening for events.
@@ -321,15 +348,7 @@ class WebSocketClient:
         self._running = True
 
         await self.connect()
-        await self.subscribe_events()  # Subscribe to state_changed
-
-        # Also subscribe to call_service events for discovery refresh triggers
-        if self.entity_discovery:
-            await self.subscribe_events("call_service")
-
-        # Subscribe to companion-app notification action taps (acknowledge)
-        if self.on_notification_action:
-            await self.subscribe_events("mobile_app_notification_action")
+        await self._resubscribe()
 
         # Start listening loop
         asyncio.create_task(self._listen_loop())

--- a/ha_boss/monitoring/websocket_client.py
+++ b/ha_boss/monitoring/websocket_client.py
@@ -308,7 +308,11 @@ class WebSocketClient:
                 break
 
             # Fire lost-connection notification once after threshold has elapsed
-            if not self._reconnect_notified and self.on_connect_lost is not None:
+            if (
+                not self._reconnect_notified
+                and self.on_connect_lost is not None
+                and self._reconnect_started_at is not None
+            ):
                 elapsed = (datetime.now(UTC) - self._reconnect_started_at).total_seconds()
                 if elapsed >= self.config.websocket.reconnect_notify_after_seconds:
                     try:

--- a/ha_boss/service/main.py
+++ b/ha_boss/service/main.py
@@ -360,6 +360,7 @@ class HABossService:
                 action_verifier.handle_service_call if action_verifier is not None else None
             ),
             on_notification_action=on_notification_action,
+            on_connect_lost=lambda: self._on_connect_lost(instance_id),
         )
         await self.websocket_clients[instance_id].start()
 
@@ -570,6 +571,28 @@ class HABossService:
             logger.error(
                 f"[{instance_id}] Error handling WebSocket state change: {e}", exc_info=True
             )
+
+    async def _on_connect_lost(self, instance_id: str) -> None:
+        """Called once when the WebSocket has been disconnected for an extended period.
+
+        Args:
+            instance_id: Home Assistant instance identifier
+        """
+        threshold_min = self.config.websocket.reconnect_notify_after_seconds // 60
+        error_msg = (
+            f"Connection to Home Assistant [{instance_id}] has been lost for "
+            f"over {threshold_min} minutes — still retrying."
+        )
+        logger.error(f"[{instance_id}] {error_msg}")
+        escalation_manager = self.escalation_managers.get(instance_id)
+        if escalation_manager:
+            try:
+                await escalation_manager.notify_connection_error(error_msg)
+            except Exception as e:
+                logger.error(
+                    f"[{instance_id}] Failed to send connection-lost notification: {e}",
+                    exc_info=True,
+                )
 
     async def _on_notification_action(self, instance_id: str, data: dict[str, Any]) -> None:
         """Handle a mobile_app_notification_action event (e.g. acknowledge tap).

--- a/tests/healing/test_escalation.py
+++ b/tests/healing/test_escalation.py
@@ -351,9 +351,17 @@ async def test_notify_issue_detected_enabled(
 
 
 @pytest.mark.asyncio
-async def test_notify_issue_detected_disabled(escalator, sample_health_issue, mock_ha_client):
-    """Test issue-detected notification is suppressed when flag is off (default)."""
-    # Default mock_config leaves on_issue_detected at its default (False)
+async def test_notify_issue_detected_disabled(mock_ha_client, sample_health_issue):
+    """Test issue-detected notification is suppressed when flag is explicitly off."""
+    config = Config(
+        home_assistant=HomeAssistantConfig(
+            url="http://homeassistant.local:8123",
+            token="test_token",
+        ),
+        notifications=NotificationsConfig(on_issue_detected=False),
+        mode="production",
+    )
+    escalator = NotificationEscalator(config, mock_ha_client)
     await escalator.notify_issue_detected(sample_health_issue)
 
     mock_ha_client.create_persistent_notification.assert_not_called()
@@ -390,3 +398,23 @@ async def test_dismiss_issue_detected_clears_without_recovery_notification(
     assert dismissed_ids == ["haboss_issue_detected_sensor_test_sensor"]
     # ...and no RECOVERY (or any) notification is created.
     mock_ha_client.create_persistent_notification.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_notify_connection_error_sends_ha_notification(escalator, mock_ha_client):
+    """notify_connection_error sends a persistent notification to HA."""
+    await escalator.notify_connection_error("Lost connection after 30 minutes")
+
+    mock_ha_client.create_persistent_notification.assert_called_once()
+    call_kwargs = mock_ha_client.create_persistent_notification.call_args
+    # Title should signal a connection error
+    title = call_kwargs.kwargs.get("title") or call_kwargs.args[1]
+    assert "Connection" in title or "connection" in title
+
+
+@pytest.mark.asyncio
+async def test_notify_connection_error_no_error_message(escalator, mock_ha_client):
+    """notify_connection_error works without an explicit error string."""
+    await escalator.notify_connection_error()
+
+    mock_ha_client.create_persistent_notification.assert_called_once()

--- a/tests/monitoring/test_websocket_client.py
+++ b/tests/monitoring/test_websocket_client.py
@@ -1,6 +1,7 @@
 """Tests for Home Assistant WebSocket client."""
 
 import json
+from datetime import UTC, datetime as real_dt, timedelta
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -374,8 +375,6 @@ async def test_reconnect_runs_indefinitely(ws_client):
 @pytest.mark.asyncio
 async def test_reconnect_fires_connection_lost_callback(ws_client):
     """on_connect_lost fires exactly once after reconnect_notify_after_seconds elapses."""
-    from datetime import UTC, datetime as real_dt, timedelta
-
     ws_client._running = True
     ws_client.config.websocket.reconnect_notify_after_seconds = 60
 

--- a/tests/monitoring/test_websocket_client.py
+++ b/tests/monitoring/test_websocket_client.py
@@ -349,20 +349,70 @@ async def test_reconnect_logic(ws_client):
 
 
 @pytest.mark.asyncio
-async def test_reconnect_exhaustion(ws_client):
-    """Test reconnection failure after max retries."""
+async def test_reconnect_runs_indefinitely(ws_client):
+    """Reconnect loop runs until _running is cleared externally, not a retry cap."""
     ws_client._running = True
-    ws_client.max_retries = 2
+    attempt_count = [0]
 
-    # Always fail
-    ws_client.connect = AsyncMock(side_effect=HomeAssistantConnectionError("Failed"))
+    async def fail_then_stop():
+        attempt_count[0] += 1
+        if attempt_count[0] >= 5:
+            ws_client._running = False
+        raise HomeAssistantConnectionError("Failed")
+
+    ws_client.connect = fail_then_stop
     ws_client.subscribe_events = AsyncMock()
 
-    with patch("asyncio.sleep"):  # Speed up test
+    with patch("asyncio.sleep"):
         await ws_client._reconnect()
 
-    # Should stop running after exhausting retries
+    # Loop ran until we explicitly stopped it — did not self-terminate
+    assert attempt_count[0] == 5
     assert not ws_client._running
+
+
+@pytest.mark.asyncio
+async def test_reconnect_fires_connection_lost_callback(ws_client):
+    """on_connect_lost fires exactly once after reconnect_notify_after_seconds elapses."""
+    from datetime import UTC, datetime as real_dt, timedelta
+
+    ws_client._running = True
+    ws_client.config.websocket.reconnect_notify_after_seconds = 60
+
+    lost_calls: list[int] = []
+
+    async def on_lost() -> None:
+        lost_calls.append(1)
+
+    ws_client.on_connect_lost = on_lost
+
+    attempt_n = [0]
+
+    async def fail_then_stop() -> None:
+        attempt_n[0] += 1
+        if attempt_n[0] >= 3:
+            ws_client._running = False
+        raise HomeAssistantConnectionError("oops")
+
+    ws_client.connect = fail_then_stop
+    ws_client.subscribe_events = AsyncMock()
+
+    t0 = real_dt(2024, 1, 1, 0, 0, 0, tzinfo=UTC)
+    call_idx = [0]
+
+    def fake_now(tz=None) -> real_dt:
+        call_idx[0] += 1
+        if call_idx[0] == 1:
+            return t0  # _reconnect_started_at assignment
+        # subsequent calls: always past the 60s threshold
+        return t0 + timedelta(seconds=90 * call_idx[0])
+
+    with patch("ha_boss.monitoring.websocket_client.datetime") as mock_dt:
+        mock_dt.now.side_effect = fake_now
+        with patch("asyncio.sleep"):
+            await ws_client._reconnect()
+
+    assert lost_calls == [1], "on_connect_lost should fire exactly once"
 
 
 @pytest.mark.asyncio

--- a/tests/monitoring/test_websocket_client.py
+++ b/tests/monitoring/test_websocket_client.py
@@ -1,7 +1,8 @@
 """Tests for Home Assistant WebSocket client."""
 
 import json
-from datetime import UTC, datetime as real_dt, timedelta
+from datetime import UTC, timedelta
+from datetime import datetime as real_dt
 from unittest.mock import AsyncMock, patch
 
 import pytest


### PR DESCRIPTION
## Summary

- **P1 — Silent WebSocket failure fixed**: Replace capped 3-attempt retry loop with infinite exponential backoff capped at `websocket.max_reconnect_delay_seconds` (300s default). Fire `on_connect_lost` callback once after `reconnect_notify_after_seconds` (1800s/30min) of continuous disconnection → `CONNECTION_ERROR` persistent HA notification. Fix `call_service` subscription gap (was missing when `entity_discovery` off but `action_verification` on). Extract `_resubscribe()` helper used by both `start()` and `_reconnect()`.
- **P2 — Config templates match reality**: `notifications.on_issue_detected` default `False`→`True` (fresh installs were silently not notifying). Rewrite `config/config.yaml` and `haboss init` template — remove dead `healing:`/`api:` blocks, document real settings.
- **P3 — CLI tells the truth**: Fix `haboss start` docstring (was 'auto-healing'). Replace always-zero healing stats in `haboss status` with Issues Detected (7d) / Recoveries (7d) / Total Health Events.

## Test plan

- [x] 460 tests pass (1 pre-existing DST failure unrelated to this change)
- [x] New tests: `test_reconnect_runs_indefinitely`, `test_reconnect_fires_connection_lost_callback`, `test_notify_connection_error_*`
- [x] Config defaults verified: `on_issue_detected=True`, `max_reconnect_delay=300`, `reconnect_notify_after=1800`

🤖 Generated with [Claude Code](https://claude.com/claude-code)