### PR TITLE
feat(notifications): source mobile_push_services from env var

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,10 @@ HA_URL=http://homeassistant.local:8123
 # Create at: http://your-ha/profile -> Long-Lived Access Tokens
 HA_TOKEN=your_long_lived_access_token_here
 
+# Optional: Mobile push target (HA Companion app notify service).
+# Substituted into config.yaml's mobile_push_services. Unset = mobile push off.
+# HABOSS_MOBILE_PUSH_SERVICE=notify.mobile_app_your_phone
+
 # Optional: Email notifications
 # EMAIL_PASSWORD=your_app_password_here
 

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -67,12 +67,13 @@ notifications:
   # Home Assistant notification service (persistent notifications in the UI)
   ha_service: "persistent_notification.create"
 
-  # Mobile push via the HA Companion app. Add your notify service(s) here.
-  # Must use the mobile_app variant (e.g. notify.mobile_app_your_phone) to
-  # support actionable "Acknowledge" button on long-press.
-  mobile_push_services: []
-  # Example:
-  #   - "notify.mobile_app_jason_s_iphone"
+  # Mobile push via the HA Companion app. Must use the mobile_app variant
+  # (e.g. notify.mobile_app_your_phone) to support the actionable "Acknowledge"
+  # button on long-press. The actual service is read from the deployment-local
+  # .env (HABOSS_MOBILE_PUSH_SERVICE=notify.mobile_app_your_phone) so a config
+  # rewrite can't wipe it; if the env var is unset, mobile push is disabled.
+  mobile_push_services:
+    - "${HABOSS_MOBILE_PUSH_SERVICE}"
 
 # Operational mode: production | dry_run | testing
 # - production: sends real notifications

--- a/config/config.yaml.example
+++ b/config/config.yaml.example
@@ -116,9 +116,11 @@ notifications:
 
   # Mobile push: also send WARNING+ notifications to the HA companion app, with an
   # "Acknowledge" action on long-press. Use the mobile_app notify SERVICES (which
-  # support action buttons), not the plain notify entities. Empty = mobile disabled.
-  # Example: ["notify.mobile_app_jasons_iphone", "notify.mobile_app_melissas_iphone"]
-  mobile_push_services: []
+  # support action buttons), not the plain notify entities. Unset = mobile disabled.
+  # The value is read from the .env (HABOSS_MOBILE_PUSH_SERVICE=notify.mobile_app_x)
+  # so it survives config rewrites; add more entries below to push to extra devices.
+  mobile_push_services:
+    - "${HABOSS_MOBILE_PUSH_SERVICE}"
 
   # Home Assistant notification service
   ha_service: "persistent_notification.create"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,9 @@ services:
       # - HA_TOKEN=${HA_TOKEN:?HA_TOKEN is required}
       - CONFIG_PATH=/app/config/config.yaml
       - TZ=${TZ:-UTC}
+      # Mobile push target, substituted into config.yaml's mobile_push_services.
+      # Set in .env; empty = mobile push disabled.
+      - HABOSS_MOBILE_PUSH_SERVICE=${HABOSS_MOBILE_PUSH_SERVICE:-}
 
     # Volume mounts for persistence
     volumes:

--- a/ha_boss/cli/commands.py
+++ b/ha_boss/cli/commands.py
@@ -157,9 +157,10 @@ monitoring:
 notifications:
   on_issue_detected: true  # Core feature — alert when a monitored entity goes bad
   ha_service: "persistent_notification.create"
-  # Add your HA Companion app notify service(s) for mobile push:
-  mobile_push_services: []
-  # - "notify.mobile_app_your_phone"
+  # Mobile push: set HABOSS_MOBILE_PUSH_SERVICE in your .env (e.g.
+  # notify.mobile_app_your_phone); unset = mobile push disabled.
+  mobile_push_services:
+    - "${HABOSS_MOBILE_PUSH_SERVICE}"
 
 # production = real notifications; dry_run = log only
 mode: production

--- a/ha_boss/core/config.py
+++ b/ha_boss/core/config.py
@@ -390,14 +390,26 @@ class NotificationsConfig(BaseSettings):
     mobile_push_services: list[str] = Field(
         default_factory=list,
         description=(
-            "notify entity_ids (e.g. 'notify.jason_s_iphone') to also send mobile push "
-            "alerts to via notify.send_message; empty = mobile push disabled"
+            "notify services (e.g. 'notify.mobile_app_your_phone') to also send mobile "
+            "push alerts to; empty = mobile push disabled. May be supplied via a "
+            "${ENV_VAR} placeholder so the value can live in .env"
         ),
     )
     ha_service: str = Field(
         default="persistent_notification.create",
         description="Home Assistant notification service",
     )
+
+    @field_validator("mobile_push_services", mode="after")
+    @classmethod
+    def _drop_unset_push_services(cls, services: list[str]) -> list[str]:
+        """Drop empty and unsubstituted ``${ENV_VAR}`` placeholder entries.
+
+        Lets the config template carry ``${HABOSS_MOBILE_PUSH_SERVICE}``; when the
+        env var is unset (placeholder left intact) or empty, the entry is removed,
+        leaving mobile push disabled instead of calling a bogus ``notify.`` service.
+        """
+        return [s for s in services if s and not (s.startswith("${") and s.endswith("}"))]
 
 
 class LoggingConfig(BaseSettings):

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -146,6 +146,42 @@ def test_load_config_env_substitution(tmp_path):
         assert config.home_assistant.instances[0].token == "env_token"
 
 
+def _mobile_push_config(tmp_path):
+    """Write a config whose mobile_push_services references ${HABOSS_MOBILE_PUSH_SERVICE}."""
+    config_file = tmp_path / "config.yaml"
+    config_data = {
+        "home_assistant": {"url": "http://test:8123", "token": "tok"},
+        "notifications": {"mobile_push_services": ["${HABOSS_MOBILE_PUSH_SERVICE}"]},
+    }
+    with open(config_file, "w") as f:
+        yaml.dump(config_data, f)
+    return config_file
+
+
+def test_mobile_push_service_from_env(tmp_path):
+    """A set env var is substituted into mobile_push_services."""
+    config_file = _mobile_push_config(tmp_path)
+    with patch.dict(os.environ, {"HABOSS_MOBILE_PUSH_SERVICE": "notify.mobile_app_phone"}):
+        config = load_config(config_file)
+    assert config.notifications.mobile_push_services == ["notify.mobile_app_phone"]
+
+
+def test_mobile_push_service_unset_placeholder_dropped(tmp_path, monkeypatch):
+    """An unset env var leaves the ${...} placeholder, which is dropped -> mobile off."""
+    monkeypatch.delenv("HABOSS_MOBILE_PUSH_SERVICE", raising=False)
+    config_file = _mobile_push_config(tmp_path)
+    config = load_config(config_file)
+    assert config.notifications.mobile_push_services == []
+
+
+def test_mobile_push_service_empty_env_dropped(tmp_path):
+    """An empty env value is dropped too -> mobile off, no bogus notify. call."""
+    config_file = _mobile_push_config(tmp_path)
+    with patch.dict(os.environ, {"HABOSS_MOBILE_PUSH_SERVICE": ""}):
+        config = load_config(config_file)
+    assert config.notifications.mobile_push_services == []
+
+
 def test_load_config_file_not_found():
     """Test error when config file doesn't exist."""
     with pytest.raises(ConfigurationError, match="not found"):


### PR DESCRIPTION
## Problem

Mobile push silently stopped reaching the phone: HA Boss created HA persistent notifications but nothing arrived on the device. Root cause was an **empty** \`mobile_push_services\` list in the deployed \`config.yaml\` — PR #284 rewrote \`config.yaml\` and reset the deployment-local value, and an empty list disables the MOBILE channel entirely (\`manager.py\` gate \`bool(config.notifications.mobile_push_services)\`). The independent HA persistent-notification channel kept working, masking the breakage.

## Fix

Move the mobile push target into \`.env\` (alongside \`HA_TOKEN\`) so a config rewrite can no longer wipe it:

- **config templates** (\`config/config.yaml\`, \`config/config.yaml.example\`, \`haboss init\` template) now reference \`\${HABOSS_MOBILE_PUSH_SERVICE}\`.
- **docker-compose.yml** passes \`HABOSS_MOBILE_PUSH_SERVICE\` through to the container.
- **\`.env.example\`** documents the new var.
- **\`NotificationsConfig._drop_unset_push_services\`** validator strips empty and unsubstituted \`\${...}\` entries, so an unset/empty var safely means \"mobile push disabled\" instead of calling a bogus \`notify.\` service.

## Tests

Added env-set / unset-placeholder / empty-string cases. Full suite: 439 passed, 1 pre-existing DST-sensitive failure (\`test_format_time_ago_naive_datetime\`, fails only on non-UTC hosts). black / ruff / mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)