### PR TITLE
Add active self-monitoring: heartbeat, self-check, canonical config

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -29,9 +29,8 @@ monitoring:
   # Entities for which "unavailable" is their normal powered-off state (e.g. TVs).
   # Matching entities are never flagged, and a turn_off that leaves them unavailable
   # is treated as success by the action verifier.
-  unavailable_ok: []
-  # Example:
-  #   - "media_player.lg_webos_tv_*"
+  unavailable_ok:
+    - "media_player.lg_webos_tv_oled65c8pua"
 
   # Auto-discovery: scope monitoring to entities used in automations/scenes/scripts.
   # Leave include: [] empty (discovery handles scoping automatically).
@@ -50,13 +49,13 @@ monitoring:
   # Action verification: warn if a service call doesn't take effect within delay_seconds.
   # Useful for catching unresponsive lights/switches.
   action_verification:
-    enabled: false
+    enabled: true
     delay_seconds: 30
 
   # Out-of-scope audit: periodic digest of unavailable entities outside your monitored set.
   # Surfaces broken integrations (Plex, PSN, OctoPrint) without spamming alerts for them.
   out_of_scope_audit:
-    enabled: false
+    enabled: true
     interval_seconds: 86400   # Once per day
 
 notifications:
@@ -74,6 +73,15 @@ notifications:
   # rewrite can't wipe it; if the env var is unset, mobile push is disabled.
   mobile_push_services:
     - "${HABOSS_MOBILE_PUSH_SERVICE}"
+
+# Dead-man's switch: HA Boss stamps this input_datetime helper every
+# interval_seconds; a Home Assistant automation alerts when the stamp goes
+# stale, so HA itself notices a dead/hung HA Boss. Requires the helper to
+# exist in HA (input_datetime.ha_boss_heartbeat).
+heartbeat:
+  enabled: true
+  entity_id: "input_datetime.ha_boss_heartbeat"
+  interval_seconds: 300  # 5 minutes; HA-side automation alerts after 15 min stale
 
 # Operational mode: production | dry_run | testing
 # - production: sends real notifications

--- a/config/config.yaml.example
+++ b/config/config.yaml.example
@@ -135,6 +135,16 @@ notifications:
   #   from: "haboss@example.com"
   #   to: "your-email@gmail.com"
 
+# Dead-man's switch: when enabled, HA Boss stamps the input_datetime helper
+# below every interval_seconds. Pair it with a Home Assistant automation that
+# alerts when the stamp goes stale (e.g. no beat for 3x the interval), so HA
+# itself notices a dead/hung HA Boss. Create the helper in HA first
+# (Settings -> Devices & Services -> Helpers -> Date and/or time).
+heartbeat:
+  enabled: false
+  entity_id: "input_datetime.ha_boss_heartbeat"
+  interval_seconds: 300
+
 # Operational mode
 # - production: Full auto-healing enabled
 # - dry_run: Log actions but don't execute

--- a/ha_boss/cli/commands.py
+++ b/ha_boss/cli/commands.py
@@ -162,6 +162,13 @@ notifications:
   mobile_push_services:
     - "${HABOSS_MOBILE_PUSH_SERVICE}"
 
+# Dead-man's switch: stamp an input_datetime helper in HA so an HA automation
+# can alert if HA Boss stops beating. Create the helper in HA before enabling.
+heartbeat:
+  enabled: false
+  entity_id: "input_datetime.ha_boss_heartbeat"
+  interval_seconds: 300
+
 # production = real notifications; dry_run = log only
 mode: production
 

--- a/ha_boss/core/config.py
+++ b/ha_boss/core/config.py
@@ -510,6 +510,30 @@ class RESTConfig(BaseSettings):
     )
 
 
+class HeartbeatConfig(BaseSettings):
+    """Dead-man's-switch heartbeat configuration.
+
+    When enabled, HA Boss periodically stamps an ``input_datetime`` helper in
+    Home Assistant. A Home Assistant automation alerts when the stamp goes
+    stale, so HA itself watches the watchdog — catching a dead container,
+    crash loop, or hung process that HA Boss cannot report on its own.
+    """
+
+    enabled: bool = Field(
+        default=False,
+        description="Send a periodic heartbeat timestamp to Home Assistant",
+    )
+    entity_id: str = Field(
+        default="input_datetime.ha_boss_heartbeat",
+        description="input_datetime helper to stamp with each heartbeat",
+    )
+    interval_seconds: int = Field(
+        default=300,
+        description="Seconds between heartbeats",
+        ge=30,
+    )
+
+
 class Config(BaseSettings):
     """Main HA Boss configuration."""
 
@@ -528,6 +552,7 @@ class Config(BaseSettings):
     database: DatabaseConfig = Field(default_factory=DatabaseConfig)
     websocket: WebSocketConfig = Field(default_factory=WebSocketConfig)
     rest: RESTConfig = Field(default_factory=RESTConfig)
+    heartbeat: HeartbeatConfig = Field(default_factory=HeartbeatConfig)
 
     mode: Literal["production", "dry_run", "testing"] = Field(
         default="production",

--- a/ha_boss/core/ha_client.py
+++ b/ha_boss/core/ha_client.py
@@ -333,13 +333,14 @@ class HomeAssistantClient:
             list[dict[str, Any]] | None, await self._request("POST", endpoint, data=service_data)
         )
 
-    async def get_services(self) -> dict[str, Any]:
+    async def get_services(self) -> list[dict[str, Any]]:
         """Get all available services.
 
         Returns:
-            Dictionary of services by domain
+            List of ``{"domain": ..., "services": {name: ...}}`` entries,
+            one per service domain (the shape ``/api/services`` returns).
         """
-        return cast(dict[str, Any], await self._request("GET", "/api/services"))
+        return cast(list[dict[str, Any]], await self._request("GET", "/api/services"))
 
     async def get_history(
         self,

--- a/ha_boss/monitoring/heartbeat.py
+++ b/ha_boss/monitoring/heartbeat.py
@@ -1,0 +1,34 @@
+"""Dead-man's-switch heartbeat.
+
+Periodically stamps an ``input_datetime`` helper in Home Assistant so an
+HA-side automation can alert when HA Boss stops beating (dead container,
+crash loop, hung process). This inverts the watching: Home Assistant itself
+watches the watchdog, covering failures HA Boss cannot report on its own.
+"""
+
+import logging
+import time
+
+from ha_boss.core.ha_client import HomeAssistantClient
+
+logger = logging.getLogger(__name__)
+
+
+async def send_heartbeat(ha_client: HomeAssistantClient, entity_id: str) -> None:
+    """Stamp the heartbeat helper with the current time.
+
+    Uses the ``timestamp`` form of ``input_datetime.set_datetime`` (epoch
+    seconds) so the value is timezone-safe regardless of container/HA locale.
+
+    Args:
+        ha_client: Home Assistant API client
+        entity_id: The input_datetime helper to stamp
+
+    Raises:
+        HomeAssistantAPIError: If the service call fails (e.g. helper missing)
+    """
+    await ha_client.call_service(
+        "input_datetime",
+        "set_datetime",
+        {"entity_id": entity_id, "timestamp": int(time.time())},
+    )

--- a/ha_boss/monitoring/self_check.py
+++ b/ha_boss/monitoring/self_check.py
@@ -1,0 +1,126 @@
+"""Self-check of HA Boss's own alerting pipeline.
+
+Every major HA Boss failure to date has been a silent self-misconfiguration
+(mobile push emptied by a config rewrite, notify service renamed, heartbeat
+target deleted) rather than a missed Home Assistant problem. This module
+actively validates the notification pipeline against the live instance at
+startup and periodically, and raises a persistent notification when something
+is off — so a broken alert path is itself alerted on.
+"""
+
+import logging
+from typing import Any
+
+from ha_boss.core.config import Config
+from ha_boss.core.ha_client import HomeAssistantClient
+from ha_boss.notifications.manager import NotificationChannel, NotificationManager
+from ha_boss.notifications.templates import (
+    NotificationContext,
+    NotificationSeverity,
+    NotificationType,
+)
+
+logger = logging.getLogger(__name__)
+
+# Stable context name so the self-check notification ID is deterministic
+# (haboss_self_check_config): repeat findings dedupe, and a clean run can
+# dismiss a previously-raised warning.
+_SELF_CHECK_CONTEXT_NAME = "config"
+
+
+def _notify_service_names(services_payload: list[dict[str, Any]]) -> set[str]:
+    """Extract notify service names from a ``/api/services`` response.
+
+    The endpoint returns a list of ``{"domain": ..., "services": {name: ...}}``
+    entries; unexpected shapes yield an empty set (treated as unvalidatable).
+    """
+    names: set[str] = set()
+    for entry in services_payload:
+        if isinstance(entry, dict) and entry.get("domain") == "notify":
+            services = entry.get("services")
+            if isinstance(services, dict):
+                names.update(services.keys())
+    return names
+
+
+async def run_self_check(
+    config: Config,
+    ha_client: HomeAssistantClient,
+    notification_manager: NotificationManager,
+    instance_id: str,
+) -> list[str]:
+    """Validate the alerting pipeline; notify (HA + CLI) about any problems.
+
+    Checks:
+    - Mobile push configured when issue alerts are enabled
+    - Every configured mobile push service exists in HA's service registry
+    - The heartbeat target helper exists (when heartbeat is enabled)
+
+    A clean run dismisses any previously-raised self-check notification.
+
+    Args:
+        config: HA Boss configuration
+        ha_client: Home Assistant API client
+        notification_manager: Manager used to raise/dismiss the warning
+        instance_id: Home Assistant instance identifier (for logging)
+
+    Returns:
+        List of human-readable problem descriptions (empty = all good).
+    """
+    problems: list[str] = []
+
+    notif = config.notifications
+    if notif.on_issue_detected and not notif.mobile_push_services:
+        problems.append(
+            "Mobile push is disabled (mobile_push_services is empty) while "
+            "on_issue_detected is enabled — alerts will only appear in the HA UI. "
+            "If unintended, set HABOSS_MOBILE_PUSH_SERVICE in .env and restart."
+        )
+
+    if notif.mobile_push_services:
+        try:
+            registry = _notify_service_names(await ha_client.get_services())
+        except Exception as e:
+            registry = None
+            problems.append(
+                f"Could not fetch the HA service registry to validate push services: {e}"
+            )
+        if registry is not None:
+            for configured in notif.mobile_push_services:
+                service_name = configured.split(".", 1)[-1]
+                if service_name not in registry:
+                    problems.append(
+                        f"Configured mobile push service '{configured}' does not exist on "
+                        "this HA instance (companion app renamed or re-registered?) — "
+                        "pushes to it are silently lost."
+                    )
+
+    if config.heartbeat.enabled:
+        try:
+            await ha_client.get_state(config.heartbeat.entity_id)
+        except Exception:
+            problems.append(
+                f"Heartbeat target '{config.heartbeat.entity_id}' not found in HA — "
+                "the dead-man's-switch automation will treat HA Boss as stale."
+            )
+
+    context = NotificationContext(
+        notification_type=NotificationType.SELF_CHECK,
+        severity=NotificationSeverity.WARNING,
+        integration_name=_SELF_CHECK_CONTEXT_NAME,
+        extra={"problems": problems},
+    )
+
+    if problems:
+        for problem in problems:
+            logger.warning(f"[{instance_id}] Self-check: {problem}")
+        # HA + CLI only: mobile may be exactly what is broken.
+        await notification_manager.notify(
+            context,
+            channels=[NotificationChannel.CLI, NotificationChannel.HOME_ASSISTANT],
+        )
+    else:
+        logger.info(f"[{instance_id}] ✓ Self-check passed: notification pipeline OK")
+        await notification_manager.dismiss(notification_manager.notification_id_for(context))
+
+    return problems

--- a/ha_boss/notifications/manager.py
+++ b/ha_boss/notifications/manager.py
@@ -67,6 +67,26 @@ class NotificationManager:
             ),
         }
 
+        # State the channel map loudly: a silently-disabled channel (e.g. mobile
+        # push emptied by a config rewrite) has historically gone unnoticed until
+        # an alert was missed.
+        mobile_state = (
+            f"on ({', '.join(config.notifications.mobile_push_services)})"
+            if self._channels[NotificationChannel.MOBILE]
+            else "OFF"
+        )
+        ha_state = "on" if self._channels[NotificationChannel.HOME_ASSISTANT] else "OFF"
+        logger.info(f"Notification channels: HA={ha_state}, CLI=on, MOBILE={mobile_state}")
+        if (
+            not self._channels[NotificationChannel.MOBILE]
+            and config.notifications.on_issue_detected
+        ):
+            logger.warning(
+                "Mobile push is DISABLED (no mobile_push_services configured) — issue "
+                "alerts will only appear as HA persistent notifications. If unintended, "
+                "set HABOSS_MOBILE_PUSH_SERVICE in .env and restart."
+            )
+
     def enable_channel(self, channel: NotificationChannel) -> None:
         """Enable a notification channel.
 

--- a/ha_boss/notifications/templates.py
+++ b/ha_boss/notifications/templates.py
@@ -13,6 +13,7 @@ class NotificationType(StrEnum):
     ISSUE_DETECTED = "issue_detected"
     OUT_OF_SCOPE_AUDIT = "out_of_scope_audit"
     ACTION_VERIFICATION_FAILED = "action_verification_failed"
+    SELF_CHECK = "self_check"
 
 
 class NotificationSeverity(StrEnum):
@@ -357,6 +358,37 @@ class ActionVerificationFailedTemplate(NotificationTemplate):
         return title, message
 
 
+class SelfCheckTemplate(NotificationTemplate):
+    """Template for self-check notifications.
+
+    Fired when the startup/periodic self-check finds problems in HA Boss's own
+    alerting pipeline (e.g. mobile push unconfigured, notify service missing).
+    """
+
+    @staticmethod
+    def render(context: NotificationContext) -> tuple[str, str]:
+        """Render self-check notification.
+
+        Expects ``context.extra["problems"]`` to be a list of human-readable
+        problem descriptions.
+
+        Args:
+            context: Notification context
+
+        Returns:
+            Tuple of (title, message)
+        """
+        title = f"{severity_emoji(context.severity)} HA Boss self-check warning".strip()
+
+        problems = (context.extra or {}).get("problems", [])
+        lines = ["**HA Boss's own alerting pipeline needs attention:**", ""]
+        lines.extend(f"- {problem}" for problem in problems)
+        lines.extend(["", "Until this is fixed, some alerts may not reach you."])
+
+        message = "\n".join(lines)
+        return title, message
+
+
 class TemplateRegistry:
     """Registry for mapping notification types to templates."""
 
@@ -365,6 +397,7 @@ class TemplateRegistry:
         NotificationType.ISSUE_DETECTED: IssueDetectedTemplate,
         NotificationType.OUT_OF_SCOPE_AUDIT: OutOfScopeAuditTemplate,
         NotificationType.ACTION_VERIFICATION_FAILED: ActionVerificationFailedTemplate,
+        NotificationType.SELF_CHECK: SelfCheckTemplate,
     }
 
     @classmethod

--- a/ha_boss/service/main.py
+++ b/ha_boss/service/main.py
@@ -173,6 +173,21 @@ class HABossService:
         )
         logger.info(f"[{instance_id}] ✓ Notification manager initialized")
 
+        # 2b. Startup self-check: validate our own alerting pipeline against the
+        # live instance (mobile push configured? notify services exist? heartbeat
+        # target present?). Non-fatal — problems are notified, not raised.
+        try:
+            from ha_boss.monitoring.self_check import run_self_check
+
+            await run_self_check(
+                config=self.config,
+                ha_client=self.ha_clients[instance_id],
+                notification_manager=self.notification_managers[instance_id],
+                instance_id=instance_id,
+            )
+        except Exception as e:
+            logger.warning(f"[{instance_id}] Startup self-check failed to run: {e}")
+
         # 3. Discover integrations
         logger.info(f"[{instance_id}] Discovering integrations...")
         self.integration_discoveries[instance_id] = IntegrationDiscovery(
@@ -488,6 +503,17 @@ class HABossService:
                 task.set_name(f"periodic_classifier_refresh_{instance_id}")
                 self._tasks.append(task)
 
+            # Dead-man's-switch heartbeat (if enabled)
+            if self.config.heartbeat.enabled:
+                task = asyncio.create_task(self._periodic_heartbeat(instance_id))
+                task.set_name(f"periodic_heartbeat_{instance_id}")
+                self._tasks.append(task)
+
+            # Daily re-run of the notification-pipeline self-check
+            task = asyncio.create_task(self._periodic_self_check(instance_id))
+            task.set_name(f"periodic_self_check_{instance_id}")
+            self._tasks.append(task)
+
         # Periodic DB cleanup (once per day, enforces retention_days)
         if self.config.database.retention_days > 0:
             task = asyncio.create_task(self._periodic_db_cleanup())
@@ -631,6 +657,73 @@ class HABossService:
                 break
             except Exception as e:
                 logger.error(f"Error during DB cleanup: {e}", exc_info=True)
+
+    async def _periodic_heartbeat(self, instance_id: str) -> None:
+        """Stamp the heartbeat helper in HA so the dead-man's-switch automation
+        can alert when HA Boss stops beating.
+
+        Beats immediately (so a restart clears staleness fast), then every
+        ``heartbeat.interval_seconds``. Failures are logged and retried on the
+        next beat.
+
+        Args:
+            instance_id: Home Assistant instance identifier
+        """
+        from ha_boss.monitoring.heartbeat import send_heartbeat
+
+        heartbeat = self.config.heartbeat
+
+        while not self._shutdown_event.is_set():
+            try:
+                ha_client = self.ha_clients.get(instance_id)
+                if ha_client:
+                    await send_heartbeat(ha_client, heartbeat.entity_id)
+                    logger.debug(f"[{instance_id}] Heartbeat sent to {heartbeat.entity_id}")
+            except asyncio.CancelledError:
+                break
+            except Exception as e:
+                logger.warning(f"[{instance_id}] Heartbeat failed: {e}")
+
+            try:
+                await asyncio.sleep(heartbeat.interval_seconds)
+            except asyncio.CancelledError:
+                break
+
+    async def _periodic_self_check(self, instance_id: str) -> None:
+        """Re-run the notification-pipeline self-check once a day.
+
+        Sleeps first: the startup self-check already ran during initialization.
+
+        Args:
+            instance_id: Home Assistant instance identifier
+        """
+        from ha_boss.monitoring.self_check import run_self_check
+
+        _ONE_DAY = 86400
+
+        while not self._shutdown_event.is_set():
+            try:
+                await asyncio.sleep(_ONE_DAY)
+            except asyncio.CancelledError:
+                break
+
+            if self._shutdown_event.is_set():
+                break
+
+            try:
+                ha_client = self.ha_clients.get(instance_id)
+                notification_manager = self.notification_managers.get(instance_id)
+                if ha_client and notification_manager:
+                    await run_self_check(
+                        config=self.config,
+                        ha_client=ha_client,
+                        notification_manager=notification_manager,
+                        instance_id=instance_id,
+                    )
+            except asyncio.CancelledError:
+                break
+            except Exception as e:
+                logger.error(f"[{instance_id}] Error in periodic self-check: {e}", exc_info=True)
 
     async def _on_websocket_state_changed(self, instance_id: str, event: dict[str, Any]) -> None:
         """Handle state_changed events from WebSocket.

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -182,6 +182,29 @@ def test_mobile_push_service_empty_env_dropped(tmp_path):
     assert config.notifications.mobile_push_services == []
 
 
+def test_heartbeat_defaults():
+    """Heartbeat is off by default with sensible target/interval."""
+    config = Config(home_assistant={"url": "http://test:8123", "token": "tok"})
+    assert config.heartbeat.enabled is False
+    assert config.heartbeat.entity_id == "input_datetime.ha_boss_heartbeat"
+    assert config.heartbeat.interval_seconds == 300
+
+
+def test_heartbeat_from_yaml(tmp_path):
+    """Heartbeat section loads from config.yaml."""
+    config_file = tmp_path / "config.yaml"
+    config_data = {
+        "home_assistant": {"url": "http://test:8123", "token": "tok"},
+        "heartbeat": {"enabled": True, "interval_seconds": 60},
+    }
+    with open(config_file, "w") as f:
+        yaml.dump(config_data, f)
+
+    config = load_config(config_file)
+    assert config.heartbeat.enabled is True
+    assert config.heartbeat.interval_seconds == 60
+
+
 def test_load_config_file_not_found():
     """Test error when config file doesn't exist."""
     with pytest.raises(ConfigurationError, match="not found"):

--- a/tests/monitoring/test_heartbeat.py
+++ b/tests/monitoring/test_heartbeat.py
@@ -1,0 +1,33 @@
+"""Tests for the dead-man's-switch heartbeat."""
+
+import time
+from unittest.mock import AsyncMock
+
+import pytest
+
+from ha_boss.monitoring.heartbeat import send_heartbeat
+
+
+@pytest.mark.asyncio
+async def test_send_heartbeat_stamps_helper_with_epoch_timestamp():
+    """Heartbeat calls input_datetime.set_datetime with a current epoch timestamp."""
+    client = AsyncMock()
+    before = int(time.time())
+
+    await send_heartbeat(client, "input_datetime.ha_boss_heartbeat")
+
+    client.call_service.assert_awaited_once()
+    domain, service, data = client.call_service.await_args.args
+    assert (domain, service) == ("input_datetime", "set_datetime")
+    assert data["entity_id"] == "input_datetime.ha_boss_heartbeat"
+    assert before <= data["timestamp"] <= int(time.time())
+
+
+@pytest.mark.asyncio
+async def test_send_heartbeat_propagates_failure():
+    """A failed service call raises so the caller can log and retry next beat."""
+    client = AsyncMock()
+    client.call_service.side_effect = Exception("HA unreachable")
+
+    with pytest.raises(Exception, match="HA unreachable"):
+        await send_heartbeat(client, "input_datetime.ha_boss_heartbeat")

--- a/tests/monitoring/test_self_check.py
+++ b/tests/monitoring/test_self_check.py
@@ -1,0 +1,139 @@
+"""Tests for the notification-pipeline self-check."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from ha_boss.core.config import Config
+from ha_boss.monitoring.self_check import run_self_check
+from ha_boss.notifications.manager import NotificationChannel
+
+
+def _config(**overrides):
+    """Build a Config with a valid instance and the given section overrides."""
+    data = {"home_assistant": {"url": "http://test:8123", "token": "tok"}}
+    data.update(overrides)
+    return Config(**data)
+
+
+def _ha_client(services=None, state_exists=True):
+    """Mock HA client with a /api/services registry and get_state behavior."""
+    client = AsyncMock()
+    client.get_services.return_value = [
+        {"domain": "notify", "services": {name: {} for name in (services or [])}},
+        {"domain": "light", "services": {"turn_on": {}, "turn_off": {}}},
+    ]
+    if state_exists:
+        client.get_state.return_value = {"entity_id": "input_datetime.ha_boss_heartbeat"}
+    else:
+        client.get_state.side_effect = Exception("404: entity not found")
+    return client
+
+
+def _notification_manager():
+    manager = MagicMock()
+    manager.notify = AsyncMock()
+    manager.dismiss = AsyncMock()
+    manager.notification_id_for.return_value = "haboss_self_check_config"
+    return manager
+
+
+@pytest.mark.asyncio
+async def test_all_good_no_problems_and_dismisses_prior_warning():
+    """A healthy pipeline reports no problems and clears any earlier warning."""
+    config = _config(
+        notifications={"mobile_push_services": ["notify.mobile_app_phone"]},
+    )
+    client = _ha_client(services=["mobile_app_phone"])
+    manager = _notification_manager()
+
+    problems = await run_self_check(config, client, manager, "default")
+
+    assert problems == []
+    manager.notify.assert_not_awaited()
+    manager.dismiss.assert_awaited_once_with("haboss_self_check_config")
+
+
+@pytest.mark.asyncio
+async def test_mobile_disabled_while_alerting_enabled_is_flagged():
+    """Empty mobile_push_services with on_issue_detected on -> warning notification."""
+    config = _config(notifications={"mobile_push_services": [], "on_issue_detected": True})
+    client = _ha_client()
+    manager = _notification_manager()
+
+    problems = await run_self_check(config, client, manager, "default")
+
+    assert len(problems) == 1
+    assert "Mobile push is disabled" in problems[0]
+    manager.notify.assert_awaited_once()
+    _, kwargs = manager.notify.await_args
+    # Mobile may be exactly what's broken: warn via HA + CLI only.
+    assert kwargs["channels"] == [
+        NotificationChannel.CLI,
+        NotificationChannel.HOME_ASSISTANT,
+    ]
+    manager.dismiss.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_configured_service_missing_from_registry_is_flagged():
+    """A push service absent from HA's registry (renamed phone) is reported."""
+    config = _config(
+        notifications={"mobile_push_services": ["notify.mobile_app_ghost"]},
+    )
+    client = _ha_client(services=["mobile_app_phone"])
+    manager = _notification_manager()
+
+    problems = await run_self_check(config, client, manager, "default")
+
+    assert len(problems) == 1
+    assert "notify.mobile_app_ghost" in problems[0]
+    manager.notify.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_registry_fetch_failure_is_flagged_not_raised():
+    """If /api/services can't be fetched, that itself is a reported problem."""
+    config = _config(
+        notifications={"mobile_push_services": ["notify.mobile_app_phone"]},
+    )
+    client = _ha_client()
+    client.get_services.side_effect = Exception("boom")
+    manager = _notification_manager()
+
+    problems = await run_self_check(config, client, manager, "default")
+
+    assert len(problems) == 1
+    assert "service registry" in problems[0]
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_target_missing_is_flagged():
+    """Heartbeat enabled but helper missing in HA -> reported."""
+    config = _config(
+        notifications={"mobile_push_services": ["notify.mobile_app_phone"]},
+        heartbeat={"enabled": True},
+    )
+    client = _ha_client(services=["mobile_app_phone"], state_exists=False)
+    manager = _notification_manager()
+
+    problems = await run_self_check(config, client, manager, "default")
+
+    assert len(problems) == 1
+    assert "input_datetime.ha_boss_heartbeat" in problems[0]
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_target_present_passes():
+    """Heartbeat enabled and helper exists -> clean run."""
+    config = _config(
+        notifications={"mobile_push_services": ["notify.mobile_app_phone"]},
+        heartbeat={"enabled": True},
+    )
+    client = _ha_client(services=["mobile_app_phone"], state_exists=True)
+    manager = _notification_manager()
+
+    problems = await run_self_check(config, client, manager, "default")
+
+    assert problems == []
+    client.get_state.assert_awaited_once_with("input_datetime.ha_boss_heartbeat")


### PR DESCRIPTION
## Why

Every major HA Boss failure to date has been a **silent self-misconfiguration**, not a missed HA problem: watching a dead sandbox while reporting healthy, mobile push emptied by a config rewrite (#284 → fixed in #285), and the same rewrite silently resetting `unavailable_ok`, `out_of_scope_audit`, and `action_verification`. This PR makes HA Boss actively verify itself.

## What

**1. Dead-man's-switch heartbeat** (new top-level `heartbeat:` config, default off)
- `monitoring/heartbeat.py`: stamps `input_datetime.ha_boss_heartbeat` in HA every `interval_seconds` (epoch-timestamp form, timezone-safe)
- An HA-side automation alerts when the stamp goes stale → HA itself notices a dead container / crash loop / hung process
- A deliberate, narrowly-scoped exception to the read-only principle (one dedicated helper)

**2. Notification-pipeline self-check** (`monitoring/self_check.py`, at startup + daily)
- Flags: mobile push disabled while `on_issue_detected` is on; a configured push service missing from HA's service registry (renamed phone = silently lost pushes); heartbeat target helper missing
- Problems → persistent notification via HA + CLI only (mobile may be the broken part); a clean run dismisses a prior warning
- `NotificationManager` now logs channel states loudly at init and warns when mobile is off

**3. `config/config.yaml` is now canonical** (secrets all live in `.env`, so the deployment-local fork is gone)
- Restores the settings the #284 rewrite silently reset: `unavailable_ok` LG TV entry, `out_of_scope_audit: true`, `action_verification: true`
- Adds the `heartbeat:` section (enabled in deploy config; off in `init`/example templates)

Also: `ha_client.get_services()` return type corrected to the list shape `/api/services` actually returns.

## Testing

+10 tests (self-check scenarios, heartbeat payload, heartbeat config). Full suite on py3.12: black/ruff/mypy clean, **449 passed**, 1 pre-existing DST-sensitive failure (`test_format_time_ago_naive_datetime`, documented in CLAUDE.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)