### PR TITLE
fix(discovery): fetch automation/script configs via REST config API

### DIFF
--- a/ha_boss/core/ha_client.py
+++ b/ha_boss/core/ha_client.py
@@ -173,6 +173,38 @@ class HomeAssistantClient:
         """
         return cast(list[dict[str, Any]], await self._request("GET", "/api/states"))
 
+    async def get_automation_config(self, automation_id: str) -> dict[str, Any]:
+        """Get an automation's full configuration by its config id.
+
+        Automation state attributes do not include triggers/conditions/actions;
+        this endpoint returns the stored configuration (modern plural keys:
+        ``triggers``/``conditions``/``actions``).
+
+        Args:
+            automation_id: The automation's ``id`` attribute (config id, not entity_id)
+
+        Returns:
+            Full automation configuration dictionary
+        """
+        return cast(
+            dict[str, Any],
+            await self._request("GET", f"/api/config/automation/config/{automation_id}"),
+        )
+
+    async def get_script_config(self, object_id: str) -> dict[str, Any]:
+        """Get a script's full configuration (including ``sequence``) by object id.
+
+        Args:
+            object_id: The script's object id (entity_id without the ``script.`` prefix)
+
+        Returns:
+            Full script configuration dictionary
+        """
+        return cast(
+            dict[str, Any],
+            await self._request("GET", f"/api/config/script/config/{object_id}"),
+        )
+
     async def _ws_command(self, command: dict[str, Any]) -> Any:
         """Run a single WebSocket request/response command.
 

--- a/ha_boss/discovery/entity_discovery.py
+++ b/ha_boss/discovery/entity_discovery.py
@@ -55,8 +55,8 @@ class EntityExtractor:
             "action": [],
         }
 
-        # Extract from triggers
-        triggers = attrs.get("trigger", [])
+        # Extract from triggers (modern configs use plural "triggers", legacy "trigger")
+        triggers = attrs.get("triggers", attrs.get("trigger", []))
         if isinstance(triggers, dict):
             triggers = [triggers]
         elif not isinstance(triggers, list):
@@ -66,13 +66,13 @@ class EntityExtractor:
             if not isinstance(trigger, dict):
                 continue
             entity_ids = EntityExtractor._extract_entity_ids_recursive(trigger)
-            platform = trigger.get("platform", "unknown")
+            platform = trigger.get("platform") or trigger.get("trigger") or "unknown"
             for entity_id in entity_ids:
                 context = {"platform": platform, "config": trigger}
                 result["trigger"].append((entity_id, context))
 
-        # Extract from conditions
-        conditions = attrs.get("condition", [])
+        # Extract from conditions (modern "conditions", legacy "condition")
+        conditions = attrs.get("conditions", attrs.get("condition", []))
         if isinstance(conditions, dict):
             conditions = [conditions]
         elif not isinstance(conditions, list):
@@ -87,8 +87,9 @@ class EntityExtractor:
                 context = {"condition_type": condition_type, "config": condition}
                 result["condition"].append((entity_id, context))
 
-        # Extract from actions
-        actions = attrs.get("action", [])
+        # Extract from actions (modern "actions", legacy "action"; steps name their
+        # service under "action" in modern configs, "service" in legacy ones)
+        actions = attrs.get("actions", attrs.get("action", []))
         if isinstance(actions, dict):
             actions = [actions]
         elif not isinstance(actions, list):
@@ -98,7 +99,7 @@ class EntityExtractor:
             if not isinstance(action, dict):
                 continue
             entity_ids = EntityExtractor._extract_entity_ids_recursive(action)
-            service = action.get("service", "unknown")
+            service = action.get("service") or action.get("action") or "unknown"
             for entity_id in entity_ids:
                 context = {"service": service, "step": idx, "config": action}
                 result["action"].append((entity_id, context))
@@ -354,8 +355,23 @@ class EntityDiscoveryService:
         attrs = auto_state.get("attributes", {})
         state = auto_state.get("state", "off")
 
+        # State attributes don't carry triggers/conditions/actions — fetch the real
+        # config via the REST config API using the automation's config id. Fall back
+        # to attributes (empty extraction) if the config can't be fetched.
+        config: dict[str, Any] = attrs
+        config_id = attrs.get("id")
+        if config_id:
+            try:
+                config = await self.ha_client.get_automation_config(str(config_id))
+            except Exception as e:
+                logger.warning(f"Could not fetch config for {entity_id} (id={config_id}): {e}")
+        else:
+            logger.warning(
+                f"{entity_id} has no 'id' attribute; cannot fetch config for entity extraction"
+            )
+
         # Extract entity references
-        entity_refs = EntityExtractor.extract_from_automation(attrs)
+        entity_refs = EntityExtractor.extract_from_automation(config)
 
         instance_id = self.ha_client.instance_id
 
@@ -369,14 +385,18 @@ class EntityDiscoveryService:
             )
             existing = result.scalar_one_or_none()
 
+            trigger_config = config.get("triggers", config.get("trigger"))
+            condition_config = config.get("conditions", config.get("condition"))
+            action_config = config.get("actions", config.get("action"))
+
             if existing:
                 # Update existing record
                 existing.friendly_name = attrs.get("friendly_name")
                 existing.state = state
                 existing.mode = attrs.get("mode")
-                existing.trigger_config = attrs.get("trigger")
-                existing.condition_config = attrs.get("condition")
-                existing.action_config = attrs.get("action")
+                existing.trigger_config = trigger_config
+                existing.condition_config = condition_config
+                existing.action_config = action_config
                 existing.last_seen = datetime.now(UTC)
             else:
                 # Insert new record
@@ -386,9 +406,9 @@ class EntityDiscoveryService:
                     friendly_name=attrs.get("friendly_name"),
                     state=state,
                     mode=attrs.get("mode"),
-                    trigger_config=attrs.get("trigger"),
-                    condition_config=attrs.get("condition"),
-                    action_config=attrs.get("action"),
+                    trigger_config=trigger_config,
+                    condition_config=condition_config,
+                    action_config=action_config,
                     discovered_at=datetime.now(UTC),
                     last_seen=datetime.now(UTC),
                 )
@@ -529,6 +549,20 @@ class EntityDiscoveryService:
 
         logger.debug(f"Processing {len(scripts)} scripts")
 
+        # A script's config-store object_id is its registry unique_id, which can
+        # differ from the entity_id suffix after a registry rename. Build the map
+        # once per refresh so renamed scripts still resolve to their config.
+        object_id_map: dict[str, str] = {}
+        try:
+            registry = await self.ha_client.get_entity_registry()
+            object_id_map = {
+                entry["entity_id"]: entry["unique_id"]
+                for entry in registry
+                if entry.get("entity_id", "").startswith("script.") and entry.get("unique_id")
+            }
+        except Exception as e:
+            logger.warning(f"Could not fetch entity registry for script object_ids: {e}")
+
         # Clear existing script relationships
         async with self.database.async_session() as session:
             await session.execute(delete(ScriptEntity))
@@ -536,15 +570,19 @@ class EntityDiscoveryService:
 
         # Process each script
         for script_state in scripts:
-            await self._process_script(script_state)
+            await self._process_script(script_state, object_id_map)
 
         return len(scripts)
 
-    async def _process_script(self, script_state: dict[str, Any]) -> None:
+    async def _process_script(
+        self, script_state: dict[str, Any], object_id_map: dict[str, str] | None = None
+    ) -> None:
         """Process a single script and store in database.
 
         Args:
             script_state: Script state from Home Assistant
+            object_id_map: entity_id → config-store object_id (registry unique_id);
+                falls back to the entity_id suffix when absent
         """
         entity_id = script_state.get("entity_id", "")
         if not entity_id:
@@ -552,8 +590,21 @@ class EntityDiscoveryService:
 
         attrs = script_state.get("attributes", {})
 
+        # State attributes don't carry the sequence — fetch the real config via the
+        # REST config API using the script's object id. Fall back to attributes
+        # (empty extraction) if the config can't be fetched.
+        config: dict[str, Any] = attrs
+        object_id = (object_id_map or {}).get(entity_id) or (
+            entity_id.split(".", 1)[1] if "." in entity_id else ""
+        )
+        if object_id:
+            try:
+                config = await self.ha_client.get_script_config(object_id)
+            except Exception as e:
+                logger.warning(f"Could not fetch config for {entity_id}: {e}")
+
         # Extract entity references
-        entity_refs = EntityExtractor.extract_from_script(attrs)
+        entity_refs = EntityExtractor.extract_from_script(config)
 
         instance_id = self.ha_client.instance_id
 
@@ -571,7 +622,7 @@ class EntityDiscoveryService:
                 # Update existing record
                 existing.friendly_name = attrs.get("friendly_name")
                 existing.mode = attrs.get("mode")
-                existing.sequence_config = attrs.get("sequence")
+                existing.sequence_config = config.get("sequence")
                 existing.last_seen = datetime.now(UTC)
             else:
                 # Insert new record
@@ -580,7 +631,7 @@ class EntityDiscoveryService:
                     entity_id=entity_id,
                     friendly_name=attrs.get("friendly_name"),
                     mode=attrs.get("mode"),
-                    sequence_config=attrs.get("sequence"),
+                    sequence_config=config.get("sequence"),
                     discovered_at=datetime.now(UTC),
                     last_seen=datetime.now(UTC),
                 )

--- a/tests/discovery/test_entity_discovery_service.py
+++ b/tests/discovery/test_entity_discovery_service.py
@@ -1,0 +1,221 @@
+"""Tests for EntityDiscoveryService config fetching and relationship persistence.
+
+Regression tests for the scenes-only discovery bug: automation and script entity
+references must come from the REST config API (state attributes never carry
+triggers/conditions/actions/sequence), and the junction tables must actually get
+rows when automations/scripts reference entities.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from sqlalchemy import select
+
+from ha_boss.core.config import Config
+from ha_boss.core.database import AutomationEntity, ScriptEntity, init_database
+from ha_boss.discovery.entity_discovery import EntityDiscoveryService
+
+
+@pytest.fixture
+def config() -> Config:
+    """Minimal config for discovery tests."""
+    return Config(home_assistant={"url": "http://localhost:8123", "token": "test_token"})
+
+
+@pytest.fixture
+def ha_client() -> MagicMock:
+    """Mock HA client with async API methods."""
+    client = MagicMock()
+    client.instance_id = "default"
+    client.get_states = AsyncMock(return_value=[])
+    client.get_automation_config = AsyncMock()
+    client.get_script_config = AsyncMock()
+    client.get_entity_registry = AsyncMock(return_value=[])
+    return client
+
+
+AUTOMATION_STATE = {
+    "entity_id": "automation.family_room_display_control",
+    "state": "on",
+    "attributes": {
+        "id": "1747334278571",
+        "friendly_name": "Family Room - Display Control",
+        "mode": "restart",
+    },
+}
+
+MODERN_AUTOMATION_CONFIG = {
+    "id": "1747334278571",
+    "alias": "Family Room - Display Control",
+    "mode": "restart",
+    "triggers": [
+        {"trigger": "state", "entity_id": "media_player.family_room_appletv", "to": "playing"},
+    ],
+    "conditions": [
+        {"condition": "state", "entity_id": "sensor.sync_box_hdmi4_status", "state": "linked"},
+    ],
+    "actions": [
+        {"action": "light.turn_off", "target": {"entity_id": "light.family_room"}},
+    ],
+}
+
+
+@pytest.mark.asyncio
+async def test_process_automation_fetches_config_and_persists_relationships(
+    tmp_path, config, ha_client
+) -> None:
+    """Automation entity refs come from the fetched config, not state attributes."""
+    db = await init_database(tmp_path / "test.db")
+    try:
+        ha_client.get_states = AsyncMock(return_value=[AUTOMATION_STATE])
+        ha_client.get_automation_config = AsyncMock(return_value=MODERN_AUTOMATION_CONFIG)
+
+        service = EntityDiscoveryService(ha_client, db, config)
+        count = await service._fetch_and_process_automations()
+
+        assert count == 1
+        ha_client.get_automation_config.assert_awaited_once_with("1747334278571")
+
+        async with db.async_session() as session:
+            result = await session.execute(select(AutomationEntity.entity_id).distinct())
+            entity_ids = {row[0] for row in result.all()}
+
+        assert entity_ids == {
+            "media_player.family_room_appletv",
+            "sensor.sync_box_hdmi4_status",
+            "light.family_room",
+        }
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_process_automation_without_config_id_persists_nothing(
+    tmp_path, config, ha_client
+) -> None:
+    """An automation without an 'id' attribute cannot be config-fetched."""
+    db = await init_database(tmp_path / "test.db")
+    try:
+        state = {
+            "entity_id": "automation.yaml_no_id",
+            "state": "on",
+            "attributes": {"friendly_name": "YAML automation"},
+        }
+        ha_client.get_states = AsyncMock(return_value=[state])
+
+        service = EntityDiscoveryService(ha_client, db, config)
+        count = await service._fetch_and_process_automations()
+
+        assert count == 1
+        ha_client.get_automation_config.assert_not_awaited()
+
+        async with db.async_session() as session:
+            result = await session.execute(select(AutomationEntity))
+            assert result.scalars().all() == []
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_process_automation_survives_config_fetch_error(tmp_path, config, ha_client) -> None:
+    """A failed config fetch degrades to no relationships without aborting the refresh."""
+    db = await init_database(tmp_path / "test.db")
+    try:
+        ha_client.get_states = AsyncMock(return_value=[AUTOMATION_STATE])
+        ha_client.get_automation_config = AsyncMock(side_effect=RuntimeError("boom"))
+
+        service = EntityDiscoveryService(ha_client, db, config)
+        count = await service._fetch_and_process_automations()
+
+        assert count == 1
+        async with db.async_session() as session:
+            result = await session.execute(select(AutomationEntity))
+            assert result.scalars().all() == []
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_process_script_fetches_config_and_persists_relationships(
+    tmp_path, config, ha_client
+) -> None:
+    """Script entity refs come from the fetched config's sequence."""
+    db = await init_database(tmp_path / "test.db")
+    try:
+        state = {
+            "entity_id": "script.family_room_tv_on",
+            "state": "off",
+            "attributes": {"friendly_name": "Family Room - TV On", "mode": "single"},
+        }
+        script_config = {
+            "alias": "Family Room - TV On",
+            "mode": "single",
+            "sequence": [
+                {
+                    "if": [
+                        {
+                            "condition": "state",
+                            "entity_id": "media_player.lg_webos_tv_oled65c8pua",
+                            "state": ["off", "unavailable"],
+                        }
+                    ],
+                    "then": [{"action": "wake_on_lan.send_magic_packet", "data": {"mac": "x"}}],
+                }
+            ],
+        }
+        ha_client.get_states = AsyncMock(return_value=[state])
+        ha_client.get_script_config = AsyncMock(return_value=script_config)
+
+        service = EntityDiscoveryService(ha_client, db, config)
+        count = await service._fetch_and_process_scripts()
+
+        assert count == 1
+        ha_client.get_script_config.assert_awaited_once_with("family_room_tv_on")
+
+        async with db.async_session() as session:
+            result = await session.execute(select(ScriptEntity.entity_id).distinct())
+            entity_ids = {row[0] for row in result.all()}
+
+        assert entity_ids == {"media_player.lg_webos_tv_oled65c8pua"}
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_process_script_uses_registry_unique_id_for_renamed_script(
+    tmp_path, config, ha_client
+) -> None:
+    """A renamed script's config lives under its registry unique_id, not its entity_id."""
+    db = await init_database(tmp_path / "test.db")
+    try:
+        state = {
+            "entity_id": "script.run_the_vacuum",
+            "state": "off",
+            "attributes": {"friendly_name": "Cleaning - Run All Vacuums"},
+        }
+        ha_client.get_states = AsyncMock(return_value=[state])
+        ha_client.get_entity_registry = AsyncMock(
+            return_value=[
+                {"entity_id": "script.run_the_vacuum", "unique_id": "run_the_vacume"},
+                {"entity_id": "light.unrelated", "unique_id": "xyz"},
+            ]
+        )
+        ha_client.get_script_config = AsyncMock(
+            return_value={
+                "sequence": [{"action": "vacuum.start", "target": {"entity_id": "vacuum.roo"}}]
+            }
+        )
+
+        service = EntityDiscoveryService(ha_client, db, config)
+        count = await service._fetch_and_process_scripts()
+
+        assert count == 1
+        ha_client.get_script_config.assert_awaited_once_with("run_the_vacume")
+
+        async with db.async_session() as session:
+            result = await session.execute(select(ScriptEntity.entity_id).distinct())
+            entity_ids = {row[0] for row in result.all()}
+
+        assert entity_ids == {"vacuum.roo"}
+    finally:
+        await db.close()

--- a/tests/discovery/test_entity_extractor.py
+++ b/tests/discovery/test_entity_extractor.py
@@ -345,3 +345,48 @@ class TestEntityExtractorEdgeCases:
         # Within each type, check for presence (set will handle duplicates)
         assert "sensor.temp" in set(trigger_entities)
         assert "sensor.temp" in set(action_entities)
+
+
+class TestEntityExtractorModernConfig:
+    """Tests for modern (2024.10+) automation config shapes from the REST config API."""
+
+    def test_extract_modern_plural_keys(self) -> None:
+        """Modern configs use triggers/conditions/actions plural keys."""
+        config = {
+            "triggers": [{"trigger": "state", "entity_id": "binary_sensor.motion", "to": "on"}],
+            "conditions": [
+                {"condition": "state", "entity_id": "sun.sun", "state": "below_horizon"}
+            ],
+            "actions": [{"action": "light.turn_on", "target": {"entity_id": "light.porch"}}],
+        }
+
+        result = EntityExtractor.extract_from_automation(config)
+
+        assert [e for e, _ in result["trigger"]] == ["binary_sensor.motion"]
+        assert [e for e, _ in result["condition"]] == ["sun.sun"]
+        assert [e for e, _ in result["action"]] == ["light.porch"]
+
+    def test_modern_context_labels(self) -> None:
+        """Platform label comes from 'trigger' key; service label from 'action' key."""
+        config = {
+            "triggers": [{"trigger": "state", "entity_id": "binary_sensor.motion"}],
+            "actions": [{"action": "light.turn_on", "target": {"entity_id": "light.porch"}}],
+        }
+
+        result = EntityExtractor.extract_from_automation(config)
+
+        _, trigger_ctx = result["trigger"][0]
+        assert trigger_ctx["platform"] == "state"
+        _, action_ctx = result["action"][0]
+        assert action_ctx["service"] == "light.turn_on"
+
+    def test_plural_keys_win_over_singular(self) -> None:
+        """If both plural and singular keys exist, plural is used."""
+        config = {
+            "triggers": [{"trigger": "state", "entity_id": "sensor.modern"}],
+            "trigger": [{"platform": "state", "entity_id": "sensor.legacy"}],
+        }
+
+        result = EntityExtractor.extract_from_automation(config)
+
+        assert [e for e, _ in result["trigger"]] == ["sensor.modern"]


### PR DESCRIPTION
## Problem

`automation_entities` and `script_entities` have been empty since day one. `EntityExtractor` reads `trigger`/`condition`/`action`/`sequence` from **state attributes**, but Home Assistant does not expose any of those there — only scenes carry their `entity_id` list in attributes. The monitored set was therefore silently scenes-only: 39 entities on the live deployment, with every automation/script-only entity (all motion sensors, the Apple TV media player, the sync box HDMI sensor, gateway/UPS sensors) never watched. The hourly "53 automations … 39 entities discovered" log counted automation objects found, not entities extracted.

## Fix

- **ha_client**: new `get_automation_config(id)` / `get_script_config(object_id)` using `/api/config/automation/config/{id}` and `/api/config/script/config/{object_id}` (verified live against HA 2026.7.2 with the deployment token).
- **entity_discovery**: fetch the real config per automation (via its `id` attribute) and per script; extraction and the stored `*_config` columns use the fetched config. A failed fetch degrades to the previous empty-extraction behavior for that one object with a WARNING, instead of aborting the refresh.
- **EntityExtractor**: understands modern plural keys (`triggers`/`conditions`/`actions`) and modern step labels (`trigger:`/`action:`) alongside legacy singular forms.
- **Renamed scripts**: config-store object_id resolved via registry `unique_id` (one WS call per refresh) — an entity-id rename does not rename the config key (live example: `script.run_the_vacuum` → config key `run_the_vacume`).

## Validation

- 457 tests pass (only the documented DST-sensitive template wart fails on non-UTC hosts); black/ruff/mypy clean on py3.12.
- Live simulation against the production HA instance: all 53 enabled automations have fetchable configs → **69 automation-derived entities** (currently 0) + 1 script-derived, on top of the 39 scene-derived.

🤖 Generated with [Claude Code](https://claude.com/claude-code)