### PR TITLE
feat(selftest): deep end-to-end self-test with HA-update detection and on-demand switch

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -83,6 +83,16 @@ heartbeat:
   entity_id: "input_datetime.ha_boss_heartbeat"
   interval_seconds: 300  # 5 minutes; HA-side automation alerts after 15 min stale
 
+# Deep self-test: end-to-end verification (WS, REST, discovery integrity,
+# notification pipeline). Runs at startup, when the HA version changes (i.e.
+# after an HA update), and on demand when the request input_boolean is turned
+# on in HA. Verdict is written to the result input_text helper. Both helpers
+# must exist in HA.
+self_test:
+  enabled: true
+  request_entity_id: "input_boolean.ha_boss_selftest_request"
+  result_entity_id: "input_text.ha_boss_selftest_result"
+
 # Operational mode: production | dry_run | testing
 # - production: sends real notifications
 # - dry_run:    logs what would be sent, no real notifications

--- a/config/config.yaml.example
+++ b/config/config.yaml.example
@@ -145,6 +145,15 @@ heartbeat:
   entity_id: "input_datetime.ha_boss_heartbeat"
   interval_seconds: 300
 
+# Deep self-test: end-to-end verification (WS, REST, discovery integrity,
+# notification pipeline) at startup, on HA version change (i.e. after an HA
+# update), and on demand via the request input_boolean. Create both helpers
+# in HA before enabling.
+self_test:
+  enabled: false
+  request_entity_id: "input_boolean.ha_boss_selftest_request"
+  result_entity_id: "input_text.ha_boss_selftest_result"
+
 # Operational mode
 # - production: Full auto-healing enabled
 # - dry_run: Log actions but don't execute

--- a/ha_boss/cli/commands.py
+++ b/ha_boss/cli/commands.py
@@ -169,6 +169,14 @@ heartbeat:
   entity_id: "input_datetime.ha_boss_heartbeat"
   interval_seconds: 300
 
+# Deep self-test: end-to-end verification at startup, on HA version change,
+# and on demand via the request input_boolean. Create both helpers in HA
+# before enabling.
+self_test:
+  enabled: false
+  request_entity_id: "input_boolean.ha_boss_selftest_request"
+  result_entity_id: "input_text.ha_boss_selftest_result"
+
 # production = real notifications; dry_run = log only
 mode: production
 

--- a/ha_boss/core/config.py
+++ b/ha_boss/core/config.py
@@ -534,6 +534,33 @@ class HeartbeatConfig(BaseSettings):
     )
 
 
+class SelfTestConfig(BaseSettings):
+    """Deep self-test configuration.
+
+    The deep self-test validates HA Boss end-to-end against the live instance:
+    WebSocket connectivity, REST reachability, discovery integrity (each source
+    that found objects must also have extracted entity references), monitored-set
+    sanity, and the notification pipeline. It runs at startup, whenever the
+    Home Assistant version changes (i.e. after an HA update), and on demand when
+    an ``input_boolean`` request helper in HA is turned on. The verdict is
+    written to an ``input_text`` helper so HA-side automations can alert on a
+    failed or stale result.
+    """
+
+    enabled: bool = Field(
+        default=False,
+        description="Enable the deep self-test (startup, HA version change, on demand)",
+    )
+    request_entity_id: str = Field(
+        default="input_boolean.ha_boss_selftest_request",
+        description="input_boolean watched for on-demand self-test requests",
+    )
+    result_entity_id: str = Field(
+        default="input_text.ha_boss_selftest_result",
+        description="input_text helper the self-test verdict is written to",
+    )
+
+
 class Config(BaseSettings):
     """Main HA Boss configuration."""
 
@@ -553,6 +580,7 @@ class Config(BaseSettings):
     websocket: WebSocketConfig = Field(default_factory=WebSocketConfig)
     rest: RESTConfig = Field(default_factory=RESTConfig)
     heartbeat: HeartbeatConfig = Field(default_factory=HeartbeatConfig)
+    self_test: SelfTestConfig = Field(default_factory=SelfTestConfig)
 
     mode: Literal["production", "dry_run", "testing"] = Field(
         default="production",

--- a/ha_boss/monitoring/deep_selftest.py
+++ b/ha_boss/monitoring/deep_selftest.py
@@ -1,0 +1,290 @@
+"""Deep end-to-end self-test of HA Boss against the live Home Assistant instance.
+
+The heartbeat proves HA Boss is alive; this proves it is *working*. Each check
+targets a failure mode that has actually occurred (or is one config rewrite away
+from occurring) while the heartbeat stayed green:
+
+- WebSocket connected and REST reachable
+- Discovery integrity: every source (automations/scenes/scripts) that found
+  objects must also have extracted entity references — a source with objects
+  but zero junction rows means extraction is silently broken and the monitored
+  set is quietly missing coverage
+- Monitored set is non-empty
+- Notification pipeline is sound (delegates to the existing self-check)
+
+The verdict is written to an ``input_text`` helper in HA so HA-side automations
+can alert on a failed or stale result, and the test can be requested on demand
+by turning on an ``input_boolean`` helper. It also runs automatically when the
+reported HA version changes — i.e. right after a Home Assistant update — which
+is when compatibility breakage would appear.
+
+Like the heartbeat, writing the two helpers is a deliberate, narrow exception
+to HA Boss's read-only principle.
+"""
+
+import json
+import logging
+from datetime import UTC, datetime
+
+from sqlalchemy import func, select
+
+from ha_boss.core.config import Config
+from ha_boss.core.database import (
+    AutomationEntity,
+    Database,
+    DiscoveryRefresh,
+    RuntimeConfig,
+    SceneEntity,
+    ScriptEntity,
+)
+from ha_boss.core.ha_client import HomeAssistantClient
+from ha_boss.monitoring.self_check import run_self_check
+from ha_boss.monitoring.websocket_client import WebSocketClient
+from ha_boss.notifications.manager import NotificationChannel, NotificationManager
+from ha_boss.notifications.templates import (
+    NotificationContext,
+    NotificationSeverity,
+    NotificationType,
+)
+
+logger = logging.getLogger(__name__)
+
+# Stable context name → deterministic notification id (haboss_self_check_selftest),
+# distinct from the pipeline self-check's "config" context.
+_SELFTEST_CONTEXT_NAME = "selftest"
+
+_LAST_HA_VERSION_KEY = "last_seen_ha_version"
+
+
+class DeepSelfTest:
+    """Runs the deep self-test and reports the verdict to Home Assistant."""
+
+    def __init__(
+        self,
+        config: Config,
+        ha_client: HomeAssistantClient,
+        database: Database,
+        notification_manager: NotificationManager,
+        websocket_client: WebSocketClient | None,
+        instance_id: str,
+    ) -> None:
+        """Initialize the deep self-test.
+
+        Args:
+            config: HA Boss configuration
+            ha_client: Home Assistant REST client
+            database: HA Boss database
+            notification_manager: Manager used for verdict notifications
+            websocket_client: The instance's WebSocket client (None in tests)
+            instance_id: Home Assistant instance identifier
+        """
+        self.config = config
+        self.ha_client = ha_client
+        self.database = database
+        self.notification_manager = notification_manager
+        self.websocket_client = websocket_client
+        self.instance_id = instance_id
+        self._running = False
+
+    async def run(self, trigger: str) -> list[str]:
+        """Run all checks, write the verdict helper, and notify on failure.
+
+        Args:
+            trigger: What initiated the run — "startup", "version_change",
+                or "switch" (on-demand request helper)
+
+        Returns:
+            List of human-readable problem descriptions (empty = PASS).
+        """
+        if self._running:
+            logger.info(f"[{self.instance_id}] Deep self-test already running; skipping")
+            return []
+        self._running = True
+        try:
+            return await self._run(trigger)
+        finally:
+            self._running = False
+
+    async def _run(self, trigger: str) -> list[str]:
+        logger.info(f"[{self.instance_id}] Deep self-test starting (trigger={trigger})")
+        problems: list[str] = []
+        ha_version: str | None = None
+
+        # REST reachability (also yields the authoritative current HA version)
+        try:
+            ha_config = await self.ha_client.get_config()
+            ha_version = ha_config.get("version")
+        except Exception as e:
+            problems.append(f"REST API unreachable: {e}")
+
+        # WebSocket connectivity
+        if self.websocket_client is not None and not self.websocket_client.is_connected():
+            problems.append("WebSocket is not connected")
+
+        # Discovery integrity + monitored set
+        problems.extend(await self._check_discovery_integrity())
+
+        # Notification pipeline (raises/dismisses its own stable-id notification)
+        try:
+            problems.extend(
+                await run_self_check(
+                    self.config, self.ha_client, self.notification_manager, self.instance_id
+                )
+            )
+        except Exception as e:
+            problems.append(f"Notification pipeline self-check crashed: {e}")
+
+        await self._write_verdict(problems, ha_version)
+        if trigger == "switch":
+            await self._reset_request_helper()
+        await self._notify(problems, ha_version, trigger)
+
+        if problems:
+            for problem in problems:
+                logger.warning(f"[{self.instance_id}] Deep self-test: {problem}")
+        else:
+            logger.info(f"[{self.instance_id}] ✓ Deep self-test passed (trigger={trigger})")
+        return problems
+
+    async def _check_discovery_integrity(self) -> list[str]:
+        """Compare the last refresh's per-source object counts to junction rows."""
+        problems: list[str] = []
+        async with self.database.async_session() as session:
+            refresh = (
+                await session.execute(
+                    select(DiscoveryRefresh)
+                    .where(DiscoveryRefresh.success.is_(True))
+                    .order_by(DiscoveryRefresh.id.desc())
+                    .limit(1)
+                )
+            ).scalar_one_or_none()
+
+            if refresh is None:
+                return ["Discovery has never completed a successful refresh"]
+
+            sources = (
+                ("automations", refresh.automations_found, AutomationEntity),
+                ("scenes", refresh.scenes_found, SceneEntity),
+                ("scripts", refresh.scripts_found, ScriptEntity),
+            )
+            total_refs = 0
+            for name, found, model in sources:
+                rows = (await session.execute(select(func.count()).select_from(model))).scalar_one()
+                total_refs += rows
+                if found > 0 and rows == 0:
+                    problems.append(
+                        f"Discovery found {found} {name} but extracted 0 entity references "
+                        f"— {name} extraction is broken and their entities are unmonitored"
+                    )
+
+            if total_refs == 0:
+                problems.append("Monitored set is empty — discovery extracted nothing")
+
+        return problems
+
+    async def _write_verdict(self, problems: list[str], ha_version: str | None) -> None:
+        """Write a short verdict to the result input_text helper."""
+        stamp = datetime.now(UTC).strftime("%Y-%m-%dT%H:%MZ")
+        version = ha_version or "unknown"
+        if problems:
+            value = f"FAIL({len(problems)}) ha={version} {stamp}"
+        else:
+            value = f"PASS ha={version} {stamp}"
+        try:
+            await self.ha_client.call_service(
+                "input_text",
+                "set_value",
+                {"entity_id": self.config.self_test.result_entity_id, "value": value},
+            )
+        except Exception as e:
+            logger.warning(
+                f"[{self.instance_id}] Could not write self-test verdict to "
+                f"{self.config.self_test.result_entity_id}: {e}"
+            )
+
+    async def _reset_request_helper(self) -> None:
+        """Turn the on-demand request input_boolean back off."""
+        try:
+            await self.ha_client.call_service(
+                "input_boolean",
+                "turn_off",
+                {"entity_id": self.config.self_test.request_entity_id},
+            )
+        except Exception as e:
+            logger.warning(
+                f"[{self.instance_id}] Could not reset "
+                f"{self.config.self_test.request_entity_id}: {e}"
+            )
+
+    async def _notify(self, problems: list[str], ha_version: str | None, trigger: str) -> None:
+        """Raise a WARNING on failure; INFO on a version-change pass; dismiss when clean."""
+        context = NotificationContext(
+            notification_type=NotificationType.SELF_CHECK,
+            severity=NotificationSeverity.WARNING if problems else NotificationSeverity.INFO,
+            integration_name=_SELFTEST_CONTEXT_NAME,
+            extra={
+                "problems": problems
+                or [f"Deep self-test passed against Home Assistant {ha_version or 'unknown'}"],
+                "trigger": trigger,
+            },
+        )
+        try:
+            if problems:
+                # All channels: unlike the pipeline self-check, the deep test's
+                # failures (discovery, connectivity) don't implicate mobile push.
+                await self.notification_manager.notify(context)
+            elif trigger == "version_change":
+                await self.notification_manager.notify(
+                    context,
+                    channels=[NotificationChannel.CLI, NotificationChannel.HOME_ASSISTANT],
+                )
+            else:
+                await self.notification_manager.dismiss(
+                    self.notification_manager.notification_id_for(context)
+                )
+        except Exception as e:
+            logger.error(f"[{self.instance_id}] Self-test notification failed: {e}", exc_info=True)
+
+    async def check_version_change(self, ha_version: str | None) -> bool:
+        """Persist the observed HA version; run the self-test when it changed.
+
+        Called from the WebSocket ``on_connected`` hook (fires on the initial
+        connect and every reconnect — an HA update always causes a reconnect).
+
+        Args:
+            ha_version: Version reported by the auth handshake (None = unknown)
+
+        Returns:
+            True when a version change was detected and the self-test ran.
+        """
+        if not ha_version:
+            return False
+
+        async with self.database.async_session() as session:
+            row = (
+                await session.execute(
+                    select(RuntimeConfig).where(RuntimeConfig.key == _LAST_HA_VERSION_KEY)
+                )
+            ).scalar_one_or_none()
+            previous = json.loads(row.value) if row else None
+
+            if row is None:
+                session.add(
+                    RuntimeConfig(
+                        key=_LAST_HA_VERSION_KEY,
+                        value=json.dumps(ha_version),
+                        value_type="string",
+                    )
+                )
+            elif previous != ha_version:
+                row.value = json.dumps(ha_version)
+            await session.commit()
+
+        if previous is not None and previous != ha_version:
+            logger.info(
+                f"[{self.instance_id}] Home Assistant version changed "
+                f"{previous} → {ha_version}; running deep self-test"
+            )
+            await self.run(trigger="version_change")
+            return True
+        return False

--- a/ha_boss/monitoring/websocket_client.py
+++ b/ha_boss/monitoring/websocket_client.py
@@ -38,6 +38,7 @@ class WebSocketClient:
         on_service_call: Callable[[dict[str, Any]], Coroutine[Any, Any, None]] | None = None,
         on_notification_action: Callable[[dict[str, Any]], Coroutine[Any, Any, None]] | None = None,
         on_connect_lost: Callable[[], Coroutine[Any, Any, None]] | None = None,
+        on_connected: Callable[[str | None], Coroutine[Any, Any, None]] | None = None,
     ) -> None:
         """Initialize WebSocket client.
 
@@ -56,6 +57,10 @@ class WebSocketClient:
             on_connect_lost: Optional async callback fired once when the connection has
                 been lost for longer than config.websocket.reconnect_notify_after_seconds.
                 Cleared on successful reconnect.
+            on_connected: Optional async callback fired after every successful
+                authentication (initial connect and each reconnect) with the HA
+                version reported in the auth handshake. Reconnects follow HA
+                restarts, so this is the natural hook for HA-update detection.
         """
         # Build WebSocket URL from HTTP URL
         ws_url = instance.url.replace("http://", "ws://").replace("https://", "wss://")
@@ -75,8 +80,10 @@ class WebSocketClient:
         self.on_service_call = on_service_call
         self.on_notification_action = on_notification_action
         self.on_connect_lost = on_connect_lost
+        self.on_connected = on_connected
 
         # State
+        self.ha_version: str | None = None  # From the last successful auth handshake
         self._ws: Any = None  # WebSocket connection
         self._message_id = 0
         self._running = False
@@ -120,9 +127,14 @@ class WebSocketClient:
                     f"Unexpected auth response: {auth_result.get('type')}"
                 )
 
-            logger.info(
-                f"WebSocket connected successfully (HA version: {auth_result.get('ha_version')})"
-            )
+            self.ha_version = auth_result.get("ha_version")
+            logger.info(f"WebSocket connected successfully (HA version: {self.ha_version})")
+
+            if self.on_connected:
+                try:
+                    await self.on_connected(self.ha_version)
+                except Exception as e:
+                    logger.error(f"Error in on_connected callback: {e}", exc_info=True)
 
         except (HomeAssistantAuthError, HomeAssistantConnectionError):
             # Re-raise our own exceptions without wrapping

--- a/ha_boss/service/main.py
+++ b/ha_boss/service/main.py
@@ -68,6 +68,7 @@ class HABossService:
         self.escalation_managers: dict[str, NotificationEscalator] = {}
         self.out_of_scope_auditors: dict[str, Any] = {}  # OutOfScopeAuditor
         self.action_verifiers: dict[str, Any] = {}  # ActionVerifier
+        self.deep_selftests: dict[str, Any] = {}  # DeepSelfTest
 
         # Background tasks
         self._tasks: list[asyncio.Task[None]] = []
@@ -368,6 +369,24 @@ class HABossService:
             if self.config.notifications.mobile_push_services
             else None
         )
+        # Deep self-test (if enabled) is created before the WebSocket client so the
+        # on_connected callback (fired during start()) finds it; the client
+        # reference is attached below, before start().
+        on_connected = None
+        if self.config.self_test.enabled:
+            from ha_boss.monitoring.deep_selftest import DeepSelfTest
+
+            self.deep_selftests[instance_id] = DeepSelfTest(
+                config=self.config,
+                ha_client=self.ha_clients[instance_id],
+                database=self.database,
+                notification_manager=self.notification_managers[instance_id],
+                websocket_client=None,
+                instance_id=instance_id,
+            )
+            on_connected = lambda ha_version: self._on_websocket_connected(  # noqa: E731
+                instance_id, ha_version
+            )
         self.websocket_clients[instance_id] = WebSocketClient(
             instance=instance,
             config=self.config,
@@ -378,7 +397,11 @@ class HABossService:
             ),
             on_notification_action=on_notification_action,
             on_connect_lost=lambda: self._on_connect_lost(instance_id),
+            on_connected=on_connected,
         )
+        if instance_id in self.deep_selftests:
+            self.deep_selftests[instance_id].websocket_client = self.websocket_clients[instance_id]
+            logger.info(f"[{instance_id}] ✓ Deep self-test initialized")
         await self.websocket_clients[instance_id].start()
 
         logger.info(f"[{instance_id}] ✓ WebSocket connected and subscribed")
@@ -448,6 +471,13 @@ class HABossService:
             # 3. Start background tasks
             logger.info("Starting background tasks...")
             self._start_background_tasks()
+
+            # 4. Startup deep self-test (if enabled) — after everything is wired,
+            # so the discovery/notification checks see the real component state.
+            for instance_id in self.deep_selftests:
+                task = asyncio.create_task(self._run_deep_selftest(instance_id, "startup"))
+                task.set_name(f"deep_selftest_startup_{instance_id}")
+                self._tasks.append(task)
 
             self.state = ServiceState.RUNNING
             logger.info("✅ HA Boss service started successfully")
@@ -733,6 +763,18 @@ class HABossService:
             event: WebSocket state_changed event data containing entity_id, new_state, old_state
         """
         try:
+            # On-demand deep self-test: request helper flipped off → on in HA
+            deep_selftest = self.deep_selftests.get(instance_id)
+            if (
+                deep_selftest is not None
+                and event.get("entity_id") == self.config.self_test.request_entity_id
+                and (event.get("new_state") or {}).get("state") == "on"
+                and (event.get("old_state") or {}).get("state") != "on"
+            ):
+                task = asyncio.create_task(self._run_deep_selftest(instance_id, "switch"))
+                task.set_name(f"deep_selftest_switch_{instance_id}")
+                self._tasks.append(task)
+
             # Update state tracker with full event data
             # event structure: {entity_id: "...", new_state: {...}, old_state: {...}}
             state_tracker = self.state_trackers.get(instance_id)
@@ -743,6 +785,44 @@ class HABossService:
             logger.error(
                 f"[{instance_id}] Error handling WebSocket state change: {e}", exc_info=True
             )
+
+    async def _on_websocket_connected(self, instance_id: str, ha_version: str | None) -> None:
+        """Handle a successful WebSocket (re)connection.
+
+        Persists the observed HA version and runs the deep self-test when it
+        changed — a reconnect follows every Home Assistant restart, so this is
+        where an HA update first becomes visible. Scheduled as a background task
+        so the connect path is never blocked by a test run.
+
+        Args:
+            instance_id: Home Assistant instance identifier
+            ha_version: HA version reported by the auth handshake
+        """
+        if instance_id not in self.deep_selftests:
+            return
+        task = asyncio.create_task(self._check_ha_version_change(instance_id, ha_version))
+        task.set_name(f"deep_selftest_version_check_{instance_id}")
+        self._tasks.append(task)
+
+    async def _run_deep_selftest(self, instance_id: str, trigger: str) -> None:
+        """Run the deep self-test, containing any failure to a log line."""
+        deep_selftest = self.deep_selftests.get(instance_id)
+        if deep_selftest is None:
+            return
+        try:
+            await deep_selftest.run(trigger=trigger)
+        except Exception as e:
+            logger.error(f"[{instance_id}] Deep self-test crashed: {e}", exc_info=True)
+
+    async def _check_ha_version_change(self, instance_id: str, ha_version: str | None) -> None:
+        """Persist the HA version and self-test on change, containing failures."""
+        deep_selftest = self.deep_selftests.get(instance_id)
+        if deep_selftest is None:
+            return
+        try:
+            await deep_selftest.check_version_change(ha_version)
+        except Exception as e:
+            logger.error(f"[{instance_id}] HA version check crashed: {e}", exc_info=True)
 
     async def _on_connect_lost(self, instance_id: str) -> None:
         """Called once when the WebSocket has been disconnected for an extended period.

--- a/tests/monitoring/test_deep_selftest.py
+++ b/tests/monitoring/test_deep_selftest.py
@@ -1,0 +1,234 @@
+"""Tests for the deep end-to-end self-test."""
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from ha_boss.core.config import Config
+from ha_boss.core.database import (
+    AutomationEntity,
+    DiscoveryRefresh,
+    SceneEntity,
+    init_database,
+)
+from ha_boss.monitoring.deep_selftest import DeepSelfTest
+
+
+@pytest.fixture
+def config() -> Config:
+    """Config with the self-test enabled."""
+    return Config(
+        home_assistant={"url": "http://localhost:8123", "token": "test_token"},
+        self_test={"enabled": True},
+    )
+
+
+@pytest.fixture
+def ha_client() -> MagicMock:
+    """Mock REST client."""
+    client = MagicMock()
+    client.get_config = AsyncMock(return_value={"version": "2026.7.2"})
+    client.call_service = AsyncMock()
+    return client
+
+
+@pytest.fixture
+def notification_manager() -> MagicMock:
+    """Mock notification manager."""
+    manager = MagicMock()
+    manager.notify = AsyncMock()
+    manager.dismiss = AsyncMock()
+    manager.notification_id_for = MagicMock(return_value="haboss_self_check_selftest")
+    return manager
+
+
+@pytest.fixture
+def ws_client() -> MagicMock:
+    """Mock WebSocket client reporting connected."""
+    client = MagicMock()
+    client.is_connected = MagicMock(return_value=True)
+    return client
+
+
+async def _seed_discovery(
+    db, automations_found: int, automation_refs: int, scene_refs: int
+) -> None:
+    """Seed a successful refresh row plus junction rows."""
+    async with db.async_session() as session:
+        session.add(
+            DiscoveryRefresh(
+                instance_id="default",
+                trigger_type="periodic",
+                trigger_source="test",
+                automations_found=automations_found,
+                scenes_found=1,
+                scripts_found=0,
+                entities_discovered=automation_refs + scene_refs,
+                duration_seconds=0.1,
+                timestamp=datetime.now(UTC),
+                success=True,
+            )
+        )
+        for i in range(automation_refs):
+            session.add(
+                AutomationEntity(
+                    instance_id="default",
+                    automation_id=f"automation.test_{i}",
+                    entity_id=f"light.test_{i}",
+                    relationship_type="action",
+                    discovered_at=datetime.now(UTC),
+                )
+            )
+        for i in range(scene_refs):
+            session.add(
+                SceneEntity(
+                    instance_id="default",
+                    scene_id="scene.test",
+                    entity_id=f"switch.test_{i}",
+                    discovered_at=datetime.now(UTC),
+                )
+            )
+        await session.commit()
+
+
+def _make_selftest(config, ha_client, db, notification_manager, ws_client) -> DeepSelfTest:
+    return DeepSelfTest(
+        config=config,
+        ha_client=ha_client,
+        database=db,
+        notification_manager=notification_manager,
+        websocket_client=ws_client,
+        instance_id="default",
+    )
+
+
+@pytest.mark.asyncio
+async def test_all_checks_pass(tmp_path, config, ha_client, notification_manager, ws_client):
+    """Healthy system → PASS verdict written, prior warning dismissed."""
+    db = await init_database(tmp_path / "test.db")
+    try:
+        await _seed_discovery(db, automations_found=5, automation_refs=3, scene_refs=2)
+        selftest = _make_selftest(config, ha_client, db, notification_manager, ws_client)
+
+        with patch("ha_boss.monitoring.deep_selftest.run_self_check", AsyncMock(return_value=[])):
+            problems = await selftest.run(trigger="startup")
+
+        assert problems == []
+        verdicts = [
+            c.args for c in ha_client.call_service.await_args_list if c.args[0] == "input_text"
+        ]
+        assert len(verdicts) == 1
+        assert verdicts[0][2]["value"].startswith("PASS ha=2026.7.2")
+        notification_manager.dismiss.assert_awaited_once()
+        notification_manager.notify.assert_not_awaited()
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_detects_broken_automation_extraction(
+    tmp_path, config, ha_client, notification_manager, ws_client
+):
+    """Objects found but zero junction rows → FAIL (the scenes-only regression)."""
+    db = await init_database(tmp_path / "test.db")
+    try:
+        await _seed_discovery(db, automations_found=53, automation_refs=0, scene_refs=39)
+        selftest = _make_selftest(config, ha_client, db, notification_manager, ws_client)
+
+        with patch("ha_boss.monitoring.deep_selftest.run_self_check", AsyncMock(return_value=[])):
+            problems = await selftest.run(trigger="startup")
+
+        assert any("automations" in p and "extraction is broken" in p for p in problems)
+        verdicts = [
+            c.args for c in ha_client.call_service.await_args_list if c.args[0] == "input_text"
+        ]
+        assert verdicts[0][2]["value"].startswith("FAIL(")
+        notification_manager.notify.assert_awaited_once()
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_ws_disconnected_is_a_problem(
+    tmp_path, config, ha_client, notification_manager, ws_client
+):
+    """A disconnected WebSocket fails the test."""
+    db = await init_database(tmp_path / "test.db")
+    try:
+        await _seed_discovery(db, automations_found=5, automation_refs=3, scene_refs=2)
+        ws_client.is_connected = MagicMock(return_value=False)
+        selftest = _make_selftest(config, ha_client, db, notification_manager, ws_client)
+
+        with patch("ha_boss.monitoring.deep_selftest.run_self_check", AsyncMock(return_value=[])):
+            problems = await selftest.run(trigger="startup")
+
+        assert any("WebSocket" in p for p in problems)
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_switch_trigger_resets_request_helper(
+    tmp_path, config, ha_client, notification_manager, ws_client
+):
+    """An on-demand run turns the request input_boolean back off."""
+    db = await init_database(tmp_path / "test.db")
+    try:
+        await _seed_discovery(db, automations_found=5, automation_refs=3, scene_refs=2)
+        selftest = _make_selftest(config, ha_client, db, notification_manager, ws_client)
+
+        with patch("ha_boss.monitoring.deep_selftest.run_self_check", AsyncMock(return_value=[])):
+            await selftest.run(trigger="switch")
+
+        resets = [
+            c.args for c in ha_client.call_service.await_args_list if c.args[0] == "input_boolean"
+        ]
+        assert resets == [
+            ("input_boolean", "turn_off", {"entity_id": config.self_test.request_entity_id})
+        ]
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_version_change_triggers_run(
+    tmp_path, config, ha_client, notification_manager, ws_client
+):
+    """First sighting stores quietly; a changed version runs the self-test."""
+    db = await init_database(tmp_path / "test.db")
+    try:
+        selftest = _make_selftest(config, ha_client, db, notification_manager, ws_client)
+        selftest.run = AsyncMock(return_value=[])  # type: ignore[method-assign]
+
+        assert await selftest.check_version_change("2026.7.2") is False
+        selftest.run.assert_not_awaited()
+
+        assert await selftest.check_version_change("2026.7.2") is False
+        selftest.run.assert_not_awaited()
+
+        assert await selftest.check_version_change("2026.8.0") is True
+        selftest.run.assert_awaited_once_with(trigger="version_change")
+
+        # The new version is persisted — seeing it again does not re-run
+        selftest.run.reset_mock()
+        assert await selftest.check_version_change("2026.8.0") is False
+        selftest.run.assert_not_awaited()
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_unknown_version_is_ignored(
+    tmp_path, config, ha_client, notification_manager, ws_client
+):
+    """A missing version in the handshake never triggers a run."""
+    db = await init_database(tmp_path / "test.db")
+    try:
+        selftest = _make_selftest(config, ha_client, db, notification_manager, ws_client)
+        selftest.run = AsyncMock(return_value=[])  # type: ignore[method-assign]
+
+        assert await selftest.check_version_change(None) is False
+        selftest.run.assert_not_awaited()
+    finally:
+        await db.close()


### PR DESCRIPTION
## Why

The heartbeat proves HA Boss is alive; this proves it is **working**. Every major failure to date was a silent self-misconfiguration behind a green heartbeat — most recently #287: discovery extracted zero automation/script entity references for months while logging healthy-looking refresh counts.

## What

**`monitoring/deep_selftest.py` — DeepSelfTest**, checks:
- WebSocket connected, REST reachable (also yields current HA version)
- **Discovery integrity**: each source whose last refresh found objects must have junction rows — would have caught the scenes-only bug on day one
- Monitored set non-empty
- Notification pipeline (delegates to the existing `run_self_check`)

**Triggers:**
- startup
- **HA version change** — `websocket_client` now captures `ha_version` from the auth handshake and fires a new `on_connected` callback; reconnects follow HA restarts, so an HA update is detected minutes after it lands. Last-seen version persisted in the existing `runtime_config` table (no migration).
- **on demand** — turning on `input_boolean.ha_boss_selftest_request` in HA runs the test; the helper is flipped back off afterwards.

**Verdict** written to `input_text.ha_boss_selftest_result` (`PASS ha=2026.7.2 <stamp>` / `FAIL(n) …`) so HA automations can alert on failed/stale results. WARNING notification (all channels) on failure; INFO (HA+CLI) on a post-update pass; clean runs dismiss prior warnings.

Config: new top-level `self_test:` block, default **disabled**; enabled in the canonical deploy config. Old images ignore it (`extra=ignore`).

## Validation

463 tests pass (6 new; only the documented DST wart fails on non-UTC hosts); black/ruff/mypy clean on py3.12.

HA-side helpers + alert automations (request boolean, result text, failed/stale alerts, post-update trigger) are created separately on the live instance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)