### PR TITLE
fix(monitoring): route state updates through the stateful health pipeline

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -19,6 +19,11 @@ monitoring:
   # Entities whose state has not changed in this long are flagged as stale (seconds)
   stale_threshold_seconds: 3600  # 1 hour
 
+  # After each WebSocket connect, suppress issue reporting for this long. An HA
+  # restart briefly blanks every entity; without this that reads as a house-wide
+  # outage and alerts on everything.
+  reconnect_settle_seconds: 120  # 2 minutes
+
   # Patterns always excluded from monitoring (fnmatch syntax)
   exclude:
     - "sensor.time*"

--- a/ha_boss/cli/commands.py
+++ b/ha_boss/cli/commands.py
@@ -146,6 +146,7 @@ home_assistant:
 monitoring:
   grace_period_seconds: 300   # Wait before alerting on unavailable entity (5 min)
   stale_threshold_seconds: 3600  # Alert if no state update within this window (1 hr)
+  reconnect_settle_seconds: 120  # Stay quiet this long after a reconnect (HA restart)
   exclude:
     - "sensor.time*"
     - "sensor.date*"

--- a/ha_boss/core/config.py
+++ b/ha_boss/core/config.py
@@ -305,6 +305,16 @@ class MonitoringConfig(BaseSettings):
         description="REST API snapshot interval for validation",
         ge=60,
     )
+    reconnect_settle_seconds: int = Field(
+        default=120,
+        description=(
+            "Suppress issue reporting for this long after each WebSocket connect. "
+            "A Home Assistant restart briefly blanks every entity; without a settling "
+            "window that reads as a house-wide outage and alerts on everything "
+            "(0 disables)"
+        ),
+        ge=0,
+    )
     health_check_interval_seconds: int = Field(
         default=60,
         description="Periodic health check interval",

--- a/ha_boss/monitoring/health_monitor.py
+++ b/ha_boss/monitoring/health_monitor.py
@@ -58,6 +58,12 @@ class HealthMonitor:
         # Track previously reported issues to avoid duplicate notifications
         self._reported_issues: set[str] = set()  # entity_id
 
+        # Settling window: while set, issues are tracked but never reported.
+        # After a reconnect the cached view of the world is stale and Home
+        # Assistant is still repopulating entities, so anything "unavailable"
+        # right now says more about the restart than about the device.
+        self._settle_until: datetime | None = None
+
         # Monitoring task
         self._monitor_task: asyncio.Task[None] | None = None
         self._running = False
@@ -101,6 +107,44 @@ class HealthMonitor:
                 continue
 
             await self._check_entity_health(entity_state)
+
+    def begin_settling_period(self, seconds: int) -> None:
+        """Suppress issue reporting for a while after a (re)connect.
+
+        Home Assistant repopulates its entities over several seconds after a
+        restart, and HA Boss's cache is stale for the length of any WebSocket
+        outage. Reporting during that window produces alerts about the restart
+        rather than about any real fault.
+
+        Args:
+            seconds: Length of the settling window (<= 0 disables it)
+        """
+        if seconds <= 0:
+            return
+
+        self._settle_until = datetime.now(UTC) + timedelta(seconds=seconds)
+        logger.info(f"Health reporting suppressed for {seconds}s while entity states re-settle")
+
+    def _is_settling(self, now: datetime) -> bool:
+        """Whether the post-(re)connect settling window is still open."""
+        return self._settle_until is not None and now < self._settle_until
+
+    async def check_entity_state(self, entity_state: EntityState) -> None:
+        """Run the full stateful health pipeline for one entity.
+
+        This is the entry point for event-driven checks. It is deliberately the
+        *same* path the periodic loop uses, so a state update honours the grace
+        period, the already-reported dedup, persistence, and recovery handling.
+
+        Do not use :meth:`check_entity_now` for this — it bypasses all of that.
+
+        Args:
+            entity_state: Current entity state
+        """
+        if not self._should_monitor_entity(entity_state.entity_id):
+            return
+
+        await self._check_entity_health(entity_state)
 
     async def _check_entity_health(self, entity_state: EntityState) -> None:
         """Check health of a single entity.
@@ -159,6 +203,13 @@ class HealthMonitor:
         """
         entity_id = entity_state.entity_id
         now = datetime.now(UTC)
+
+        # Inside the settling window, keep tracking but restart the grace clock:
+        # an entity must be continuously unhealthy for a full grace period after
+        # things settle before it is worth waking someone up about.
+        if self._is_settling(now):
+            self._issue_tracker[entity_id] = (issue_type, now)
+            return
 
         # Check if this is a new issue or continuation
         if entity_id in self._issue_tracker:
@@ -282,6 +333,15 @@ class HealthMonitor:
         # Persist to database
         await self._persist_health_event(issue)
 
+        # Tell the service, so it can clear the alert it raised for this entity.
+        # Without this the recovery is only ever written to the database and the
+        # notification stays up until the user dismisses it by hand.
+        if self.on_issue_detected:
+            try:
+                await self.on_issue_detected(issue)
+            except Exception as e:
+                logger.error(f"Error in recovery callback: {e}", exc_info=True)
+
     async def _persist_health_event(self, issue: HealthIssue) -> None:
         """Persist health event to database.
 
@@ -338,7 +398,16 @@ class HealthMonitor:
         return bool(self.integration_classifier.is_cloud(entity_id))
 
     async def check_entity_now(self, entity_id: str) -> HealthIssue | None:
-        """Manually check health of a specific entity (bypasses grace period).
+        """Report an entity's current health, ignoring all reporting state.
+
+        A stateless point-in-time query for interactive use. It deliberately
+        bypasses the grace period, the already-reported dedup, the settling
+        window, and persistence.
+
+        **Never drive notifications from this.** Doing so was the cause of a
+        47-alert storm: it was called on every state update, so a Home Assistant
+        restart alerted on every entity the instant it blinked out. Use
+        :meth:`check_entity_state` for anything that can raise an alert.
 
         Args:
             entity_id: Entity identifier

--- a/ha_boss/service/main.py
+++ b/ha_boss/service/main.py
@@ -940,10 +940,19 @@ class HABossService:
         where an HA update first becomes visible. Scheduled as a background task
         so the connect path is never blocked by a test run.
 
+        Also opens a settling window on the health monitor. A connect means
+        either startup or a reconnect after an outage; in both cases the cached
+        entity states are stale and Home Assistant may still be repopulating,
+        so alerting immediately reports the restart rather than a real fault.
+
         Args:
             instance_id: Home Assistant instance identifier
             ha_version: HA version reported by the auth handshake
         """
+        health_monitor = self.health_monitors.get(instance_id)
+        if health_monitor is not None:
+            health_monitor.begin_settling_period(self.config.monitoring.reconnect_settle_seconds)
+
         if instance_id not in self.deep_selftests:
             return
         task = asyncio.create_task(self._check_ha_version_change(instance_id, ha_version))
@@ -1021,18 +1030,15 @@ class HABossService:
             old_state: Previous state (if any)
         """
 
-        # Trigger health check for this specific entity on the correct instance
+        # Feed the update into the health monitor's stateful pipeline. It reports
+        # through the on_issue_detected callback itself (after the grace period,
+        # deduped, and persisted), so this must not also notify — an earlier
+        # version called the grace-bypassing check_entity_now() here and alerted
+        # on every single state event.
         health_monitor = self.health_monitors.get(instance_id)
         if health_monitor:
             try:
-                issue = await health_monitor.check_entity_now(new_state.entity_id)
-                if issue:
-                    logger.debug(
-                        f"[{instance_id}] State update triggered health issue for "
-                        f"{new_state.entity_id}: {issue.issue_type}"
-                    )
-                    # Trigger healing for this issue
-                    await self._on_health_issue(instance_id, issue)
+                await health_monitor.check_entity_state(new_state)
             except Exception as e:
                 logger.error(
                     f"[{instance_id}] Error checking health for {new_state.entity_id}: {e}",

--- a/tests/monitoring/test_health_monitor.py
+++ b/tests/monitoring/test_health_monitor.py
@@ -589,3 +589,222 @@ class TestCreateHealthMonitor:
             )
 
             assert monitor.on_issue_detected == callback
+
+
+def _unavailable(entity_id: str = "sensor.test") -> EntityState:
+    """An entity in an unhealthy state, updated just now."""
+    return EntityState(
+        entity_id=entity_id,
+        state="unavailable",
+        last_updated=datetime.now(UTC),
+    )
+
+
+def _healthy(entity_id: str = "sensor.test") -> EntityState:
+    """An entity in a healthy state, updated just now."""
+    return EntityState(
+        entity_id=entity_id,
+        state="on",
+        last_updated=datetime.now(UTC),
+    )
+
+
+class TestCheckEntityState:
+    """The event-driven path must honour grace, dedup, and persistence."""
+
+    @pytest.mark.asyncio
+    async def test_does_not_report_inside_grace_period(self, health_monitor: HealthMonitor) -> None:
+        """A blip must not alert.
+
+        Regression: state updates used to run check_entity_now(), which bypasses
+        the grace period — a Home Assistant restart alerted on every entity.
+        """
+        reported: list[HealthIssue] = []
+
+        async def on_issue(issue: HealthIssue) -> None:
+            reported.append(issue)
+
+        health_monitor.on_issue_detected = on_issue
+
+        with patch.object(health_monitor, "_persist_health_event", new_callable=AsyncMock):
+            # Several updates in quick succession, all well inside the 300s grace
+            for _ in range(5):
+                await health_monitor.check_entity_state(_unavailable())
+
+        assert reported == []
+
+    @pytest.mark.asyncio
+    async def test_reports_once_after_grace_elapses(self, health_monitor: HealthMonitor) -> None:
+        """After grace, report exactly once no matter how many updates arrive."""
+        reported: list[HealthIssue] = []
+
+        async def on_issue(issue: HealthIssue) -> None:
+            reported.append(issue)
+
+        health_monitor.on_issue_detected = on_issue
+
+        with patch.object(health_monitor, "_persist_health_event", new_callable=AsyncMock):
+            await health_monitor.check_entity_state(_unavailable())
+            # Backdate first detection past the grace period
+            health_monitor._issue_tracker["sensor.test"] = (
+                "unavailable",
+                datetime.now(UTC) - timedelta(seconds=400),
+            )
+            for _ in range(5):
+                await health_monitor.check_entity_state(_unavailable())
+
+        assert len(reported) == 1
+        assert reported[0].issue_type == "unavailable"
+
+    @pytest.mark.asyncio
+    async def test_reported_issue_is_persisted(self, health_monitor: HealthMonitor) -> None:
+        """Every reported issue lands in health_events.
+
+        Regression: the bypass path never persisted, so the table stayed empty
+        and `haboss status` reported zero issues through a week of alerts.
+        """
+        with patch.object(
+            health_monitor, "_persist_health_event", new_callable=AsyncMock
+        ) as mock_persist:
+            await health_monitor.check_entity_state(_unavailable())
+            health_monitor._issue_tracker["sensor.test"] = (
+                "unavailable",
+                datetime.now(UTC) - timedelta(seconds=400),
+            )
+            await health_monitor.check_entity_state(_unavailable())
+
+        mock_persist.assert_awaited_once()
+        assert mock_persist.await_args.args[0].issue_type == "unavailable"
+
+    @pytest.mark.asyncio
+    async def test_skips_excluded_entities(self, health_monitor: HealthMonitor) -> None:
+        """Excluded entities never enter the pipeline."""
+        with patch.object(health_monitor, "_persist_health_event", new_callable=AsyncMock):
+            await health_monitor.check_entity_state(_unavailable("sensor.time_utc"))
+
+        assert health_monitor._issue_tracker == {}
+
+
+class TestRecoveryNotifiesService:
+    """Recovery has to reach the service or the alert never clears."""
+
+    @pytest.mark.asyncio
+    async def test_recovery_invokes_callback(self, health_monitor: HealthMonitor) -> None:
+        """Regression: recovery only persisted, so notifications stayed up forever."""
+        reported: list[HealthIssue] = []
+
+        async def on_issue(issue: HealthIssue) -> None:
+            reported.append(issue)
+
+        health_monitor.on_issue_detected = on_issue
+        health_monitor._issue_tracker["sensor.test"] = (
+            "unavailable",
+            datetime.now(UTC) - timedelta(seconds=400),
+        )
+        health_monitor._reported_issues.add("sensor.test")
+
+        with patch.object(health_monitor, "_persist_health_event", new_callable=AsyncMock):
+            await health_monitor.check_entity_state(_healthy())
+
+        assert [i.issue_type for i in reported] == ["recovered"]
+        assert "sensor.test" not in health_monitor._reported_issues
+
+    @pytest.mark.asyncio
+    async def test_recovery_inside_grace_stays_silent(self, health_monitor: HealthMonitor) -> None:
+        """An entity that never alerted has nothing to clear."""
+        reported: list[HealthIssue] = []
+
+        async def on_issue(issue: HealthIssue) -> None:
+            reported.append(issue)
+
+        health_monitor.on_issue_detected = on_issue
+        health_monitor._issue_tracker["sensor.test"] = ("unavailable", datetime.now(UTC))
+
+        with patch.object(health_monitor, "_persist_health_event", new_callable=AsyncMock):
+            await health_monitor.check_entity_state(_healthy())
+
+        assert reported == []
+
+    @pytest.mark.asyncio
+    async def test_recovery_callback_error_is_contained(
+        self, health_monitor: HealthMonitor
+    ) -> None:
+        """A failing consumer must not break the monitor loop."""
+
+        async def on_issue(issue: HealthIssue) -> None:
+            raise ValueError("consumer exploded")
+
+        health_monitor.on_issue_detected = on_issue
+        health_monitor._issue_tracker["sensor.test"] = ("unavailable", datetime.now(UTC))
+        health_monitor._reported_issues.add("sensor.test")
+
+        with patch.object(health_monitor, "_persist_health_event", new_callable=AsyncMock):
+            await health_monitor.check_entity_state(_healthy())  # must not raise
+
+
+class TestSettlingPeriod:
+    """After a reconnect, let reality re-settle before judging it."""
+
+    @pytest.mark.asyncio
+    async def test_no_reports_while_settling(self, health_monitor: HealthMonitor) -> None:
+        """The HA-restart storm: everything unavailable at once, right after connect."""
+        reported: list[HealthIssue] = []
+
+        async def on_issue(issue: HealthIssue) -> None:
+            reported.append(issue)
+
+        health_monitor.on_issue_detected = on_issue
+        # Entity was already past grace before the restart
+        health_monitor._issue_tracker["sensor.test"] = (
+            "unavailable",
+            datetime.now(UTC) - timedelta(seconds=400),
+        )
+        health_monitor.begin_settling_period(120)
+
+        with patch.object(health_monitor, "_persist_health_event", new_callable=AsyncMock):
+            await health_monitor.check_entity_state(_unavailable())
+
+        assert reported == []
+
+    @pytest.mark.asyncio
+    async def test_settling_restarts_the_grace_clock(self, health_monitor: HealthMonitor) -> None:
+        """Time spent unavailable during the settling window does not count."""
+        health_monitor._issue_tracker["sensor.test"] = (
+            "unavailable",
+            datetime.now(UTC) - timedelta(seconds=400),
+        )
+        health_monitor.begin_settling_period(120)
+
+        with patch.object(health_monitor, "_persist_health_event", new_callable=AsyncMock):
+            await health_monitor.check_entity_state(_unavailable())
+
+        _, first_detected = health_monitor._issue_tracker["sensor.test"]
+        assert (datetime.now(UTC) - first_detected).total_seconds() < 5
+
+    @pytest.mark.asyncio
+    async def test_reports_resume_after_settling(self, health_monitor: HealthMonitor) -> None:
+        """A genuinely dead device still alerts once the window closes."""
+        reported: list[HealthIssue] = []
+
+        async def on_issue(issue: HealthIssue) -> None:
+            reported.append(issue)
+
+        health_monitor.on_issue_detected = on_issue
+        health_monitor.begin_settling_period(120)
+        # Window has now closed, and the entity has been bad for longer than grace
+        health_monitor._settle_until = datetime.now(UTC) - timedelta(seconds=1)
+        health_monitor._issue_tracker["sensor.test"] = (
+            "unavailable",
+            datetime.now(UTC) - timedelta(seconds=400),
+        )
+
+        with patch.object(health_monitor, "_persist_health_event", new_callable=AsyncMock):
+            await health_monitor.check_entity_state(_unavailable())
+
+        assert [i.issue_type for i in reported] == ["unavailable"]
+
+    def test_zero_disables_settling(self, health_monitor: HealthMonitor) -> None:
+        """Opting out leaves reporting immediate."""
+        health_monitor.begin_settling_period(0)
+        assert health_monitor._settle_until is None
+        assert not health_monitor._is_settling(datetime.now(UTC))

--- a/tests/service/test_main.py
+++ b/tests/service/test_main.py
@@ -7,7 +7,7 @@ Tests verify multi-instance service architecture with:
 """
 
 from datetime import UTC, datetime
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -265,27 +265,78 @@ class TestHABossServiceCallbacks:
     """Test service callback handlers."""
 
     @pytest.mark.asyncio
-    async def test_on_state_updated_triggers_health_check(self, service: HABossService) -> None:
-        """Test that state updates trigger health checks."""
-        # Set up mocks for default instance
+    async def test_on_state_updated_uses_stateful_pipeline(self, service: HABossService) -> None:
+        """State updates go through the grace-aware pipeline, not the bypass.
+
+        Regression: this used to call `check_entity_now`, which ignores the grace
+        period and the reported-issue dedup, so every state event alerted.
+        """
         service.ha_clients["default"] = AsyncMock()
 
         mock_health_monitor = AsyncMock()
-        mock_health_monitor.check_entity_now = AsyncMock(return_value=None)
         service.health_monitors["default"] = mock_health_monitor
 
-        # Create state
         new_state = EntityState(
             entity_id="sensor.test",
             state="unavailable",
             last_updated=datetime.now(UTC),
         )
 
-        # Call with instance_id parameter
         await service._on_state_updated("default", new_state, None)
 
-        # Verify health check was called
-        mock_health_monitor.check_entity_now.assert_called_once_with("sensor.test")
+        mock_health_monitor.check_entity_state.assert_awaited_once_with(new_state)
+        mock_health_monitor.check_entity_now.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_on_state_updated_does_not_notify_directly(self, service: HABossService) -> None:
+        """The state path must not raise alerts itself — the monitor's callback does.
+
+        Notifying here as well as from the pipeline would double every alert.
+        """
+        service.ha_clients["default"] = AsyncMock()
+        service.health_monitors["default"] = AsyncMock()
+        mock_escalation = AsyncMock()
+        service.escalation_managers["default"] = mock_escalation
+
+        new_state = EntityState(
+            entity_id="sensor.test",
+            state="unavailable",
+            last_updated=datetime.now(UTC),
+        )
+
+        await service._on_state_updated("default", new_state, None)
+
+        mock_escalation.notify_issue_detected.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_on_health_issue_dismisses_alert_on_recovery(
+        self, service: HABossService
+    ) -> None:
+        """Recovery clears the alert that was raised for the entity."""
+        service.config.notifications.on_issue_detected = True
+        mock_escalation = AsyncMock()
+        service.escalation_managers["default"] = mock_escalation
+
+        issue = HealthIssue(
+            entity_id="sensor.test",
+            issue_type="recovered",
+            detected_at=datetime.now(UTC),
+        )
+        await service._on_health_issue("default", issue)
+
+        mock_escalation.dismiss_issue_detected.assert_awaited_once_with("sensor.test")
+
+    @pytest.mark.asyncio
+    async def test_websocket_connect_opens_settling_window(self, service: HABossService) -> None:
+        """Every connect (startup or reconnect) quiets reporting while HA repopulates."""
+        service.config.monitoring.reconnect_settle_seconds = 120
+        mock_health_monitor = AsyncMock()
+        mock_health_monitor.begin_settling_period = MagicMock()
+        service.health_monitors["default"] = mock_health_monitor
+
+        await service._on_websocket_connected("default", "2026.7.4")
+
+        mock_health_monitor.begin_settling_period.assert_called_once_with(120)
 
     @pytest.mark.asyncio
     async def test_on_health_issue_notifies_on_detection(self, service: HABossService) -> None:


### PR DESCRIPTION
## One bug, three symptoms

`_on_state_updated` called `HealthMonitor.check_entity_now()` — a stateless helper explicitly documented as *"bypasses grace period"* — on **every state event**, and fed the result straight to the notifier. That single call site (`main.py:1028`) caused all three of the open issues:

**1. Alert storms.** The 300s grace never applied on the event path, so an HA restart alerted on every entity the instant it blinked out. A restart during testing produced **47 mobile pushes in two minutes**; `light.glide_hexa_segment_016` alerted at 16:06:11 and was healthy again at 16:06:13. It also defeated the `_reported_issues` dedup, which is why a flaky entity re-alerted every couple of hours.

**2. No issue history.** That path never persisted. `health_events` held **3 rows** — all written by the periodic loop at startup — through a week of alerts, so `haboss status` reported `Issues Detected (7d): 0`.

**3. Alerts that never cleared.** `check_entity_now()` returns `None` for a healthy entity, so recovery never reached the service. `_report_recovery` only persisted and never invoked the callback either, so `dismiss_issue_detected()` was unreachable from **both** paths — zero dismissals were ever logged.

## Changes

- **`HealthMonitor.check_entity_state()`** — new entry point running the same stateful pipeline the periodic loop uses (grace, dedup, persistence, recovery). `_on_state_updated` calls it and no longer notifies directly; the monitor's own `on_issue_detected` callback does that, so notifying here too would double every alert.
- **`_report_recovery` invokes the callback**, so recovery reaches `_on_health_issue` and clears the alert it raised.
- **`monitoring.reconnect_settle_seconds`** (default 120) opens a settling window on every WebSocket connect. Inside it, issues are still tracked but the grace clock restarts instead of reporting — after a restart the cache is stale and HA is still repopulating, so "unavailable" describes the restart, not a fault.
- **`check_entity_now()` keeps its stateless semantics** for interactive use, with a docstring that says plainly never to drive notifications from it.

## Effect on the storm

With the grace period actually applied, the entities in that storm (unavailable ~60s, well inside 300s) would never have reported at all. The settling window is the second line of defence for the case where the cache is stale across a longer outage.

## Testing

501 tests pass (14 new); black/ruff/mypy clean. New tests cover: no report inside grace, exactly one report after grace across repeated updates, reported issues are persisted, excluded entities skipped, recovery invokes the callback and clears `_reported_issues`, recovery inside grace stays silent, a throwing consumer is contained, and the four settling-window behaviours (silent while settling, grace clock restarts, reports resume after, zero disables).

🤖 Generated with [Claude Code](https://claude.com/claude-code)