### PR TITLE
feat(sentinel): add out-of-band Home Assistant liveness prober

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,6 +94,8 @@ data/
 
 # User-specific service files
 *.service
+# ...except the HA Sentinel unit, which is a shipped deployment artifact.
+!ha_sentinel/*.service
 
 # Temporary summary/report files
 *_SUMMARY.md

--- a/ha_sentinel/README.md
+++ b/ha_sentinel/README.md
@@ -1,0 +1,98 @@
+# HA Sentinel
+
+An out-of-band liveness prober for Home Assistant. It answers the one question
+Home Assistant cannot answer about itself: **is Home Assistant reachable?**
+
+Every alert goes to Pushover directly. Nothing routes through Home Assistant —
+HA being down is the thing being reported, so an HA-delivered alert would be
+useless exactly when it matters. This is the complement to the HA-native device
+health automations (`System - Battery Low`, `System - Device Health (Daily
+Digest)`, `System - Device Offline`), which handle everything *inside* a working
+HA and cannot go blind while HA is up.
+
+Standard library only. No dependencies, no database, no container.
+
+## Deployed layout (host: blackbox)
+
+| Path | Purpose |
+|------|---------|
+| `/opt/ha-sentinel/ha_sentinel.py` | The prober |
+| `/etc/systemd/system/ha-sentinel.service` | systemd unit (`Restart=always`) |
+| `/etc/ha-sentinel.env` | Config + secrets, mode 0640 root:jason |
+
+Deliberately **not** a Docker container and with no dependency on
+`docker.service`: the watchdog must survive Docker dying.
+
+## Finish the setup
+
+Alerts are inert until Pushover credentials are present. The service logs
+`WOULD ALERT (Pushover not configured)` in that state.
+
+1. Create an account at <https://pushover.net> and note your **User Key**.
+2. Create an Application (Pushover → *Create an Application/API Token*) to get
+   an **API Token**.
+3. Fill both into the env file and restart:
+
+   ```bash
+   sudo nano /etc/ha-sentinel.env      # set PUSHOVER_TOKEN= and PUSHOVER_USER=
+   sudo systemctl restart ha-sentinel
+   journalctl -u ha-sentinel -f
+   ```
+
+4. Confirm the chain end to end by pointing it at a dead port for a minute:
+
+   ```bash
+   sudo systemctl stop ha-sentinel
+   sudo HA_URL=https://127.0.0.1:9/ HA_TOKEN=x CHECK_INTERVAL_SECONDS=2 \
+        FAIL_THRESHOLD=2 PUSHOVER_TOKEN=... PUSHOVER_USER=... \
+        python3 /opt/ha-sentinel/ha_sentinel.py
+   # expect a push within ~5s, then Ctrl-C
+   sudo systemctl start ha-sentinel
+   ```
+
+## Configuration
+
+| Variable | Default | Meaning |
+|----------|---------|---------|
+| `HA_URL` | *required* | Home Assistant base URL |
+| `HA_TOKEN` | *required* | Long-lived access token |
+| `PUSHOVER_TOKEN` | — | Pushover application token |
+| `PUSHOVER_USER` | — | Pushover user key |
+| `CHECK_INTERVAL_SECONDS` | `60` | Seconds between probes |
+| `PROBE_TIMEOUT_SECONDS` | `10` | Per-probe HTTP timeout |
+| `FAIL_THRESHOLD` | `3` | Consecutive failures before alerting |
+| `REMIND_MINUTES` | `30` | Re-alert cadence while still down |
+| `DAILY_OK_HOUR` | `9` | Hour for the proof-of-life message; empty disables |
+
+## Behaviour
+
+- Probes `GET {HA_URL}/api/` and requires HTTP 200 with a JSON body.
+- Alerts (priority 1) after `FAIL_THRESHOLD` consecutive failures, so a single
+  blip or a brief restart does not page you.
+- Re-alerts every `REMIND_MINUTES` while down, so the alert cannot be lost.
+- Sends a recovery message with the measured downtime when HA returns.
+- Sends one low-priority message a day at `DAILY_OK_HOUR`.
+
+That daily message is the point, not noise: it is the dead-man's switch for the
+prober itself. It proves in one shot that the process is alive, the network
+works, and the Pushover credentials are still valid. **Silence on a day you
+expect it is the signal.** Without it, a dead prober is indistinguishable from a
+healthy house — which is precisely the failure mode that made the previous
+watchdog useless.
+
+## Known limits (deliberate)
+
+- If **blackbox** loses power or network, no alerts. Detecting that needs a
+  probe outside the house; the daily proof-of-life is the cheap mitigation.
+- A wrong/expired `HA_TOKEN` reports as an outage (HTTP 401). That is a real
+  problem worth paging for, but the message will say `HTTP 401` rather than
+  "unreachable".
+- It reports reachability only. Anything about devices *inside* a working HA is
+  the HA-native automations' job, by design.
+
+## Verified 2026-07-27
+
+- Healthy probe against live HA (`API running.`), clean SIGTERM shutdown.
+- Outage escalation: alert at the threshold, then reminders.
+- Recovery transition with downtime reported.
+- `systemctl kill -9` → systemd restarted the service 15s later.

--- a/ha_sentinel/ha-sentinel.service
+++ b/ha_sentinel/ha-sentinel.service
@@ -1,0 +1,26 @@
+[Unit]
+Description=HA Sentinel - out-of-band Home Assistant liveness prober
+Documentation=https://github.com/jasonthagerty
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=jason
+EnvironmentFile=/etc/ha-sentinel.env
+ExecStart=/usr/bin/python3 /opt/ha-sentinel/ha_sentinel.py
+Restart=always
+RestartSec=15
+# Deliberately NOT dependent on docker.service: this must survive Docker dying.
+
+# Hardening - it only needs outbound network.
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectSystem=strict
+ProtectHome=true
+ProtectKernelTunables=true
+ProtectControlGroups=true
+RestrictAddressFamilies=AF_INET AF_INET6
+
+[Install]
+WantedBy=multi-user.target

--- a/ha_sentinel/ha_sentinel.py
+++ b/ha_sentinel/ha_sentinel.py
@@ -1,0 +1,256 @@
+#!/usr/bin/env python3
+"""Out-of-band liveness prober for Home Assistant.
+
+Answers exactly one question that Home Assistant cannot answer about itself:
+is Home Assistant reachable? Every alert channel goes to Pushover directly,
+never through HA, because HA being down is the thing we are reporting.
+
+Runs on a host that is not the HA machine. Standard library only.
+"""
+
+import json
+import logging
+import os
+import signal
+import ssl
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from datetime import datetime, timedelta
+
+PUSHOVER_URL = "https://api.pushover.net/1/messages.json"
+
+log = logging.getLogger("ha_sentinel")
+
+
+class Config:
+    """Runtime configuration, read once from the environment."""
+
+    def __init__(self) -> None:
+        self.ha_url = os.environ["HA_URL"].rstrip("/")
+        self.ha_token = os.environ["HA_TOKEN"]
+        self.pushover_token = os.environ.get("PUSHOVER_TOKEN", "")
+        self.pushover_user = os.environ.get("PUSHOVER_USER", "")
+        self.interval = int(os.environ.get("CHECK_INTERVAL_SECONDS", "60"))
+        self.timeout = int(os.environ.get("PROBE_TIMEOUT_SECONDS", "10"))
+        self.fail_threshold = int(os.environ.get("FAIL_THRESHOLD", "3"))
+        self.remind_minutes = int(os.environ.get("REMIND_MINUTES", "30"))
+        # Empty disables the daily proof-of-life message.
+        hour = os.environ.get("DAILY_OK_HOUR", "").strip()
+        self.daily_ok_hour = int(hour) if hour else None
+
+    @property
+    def can_notify(self) -> bool:
+        return bool(self.pushover_token and self.pushover_user)
+
+
+def send_pushover(cfg: Config, title: str, message: str, priority: int = 0) -> bool:
+    """Send one Pushover message. Returns True on success.
+
+    Never raises: a notification failure must not kill the prober.
+    """
+    if not cfg.can_notify:
+        log.error("WOULD ALERT (Pushover not configured): %s - %s", title, message)
+        return False
+
+    payload = urllib.parse.urlencode(
+        {
+            "token": cfg.pushover_token,
+            "user": cfg.pushover_user,
+            "title": title,
+            "message": message,
+            "priority": priority,
+        }
+    ).encode()
+
+    try:
+        req = urllib.request.Request(PUSHOVER_URL, data=payload)
+        with urllib.request.urlopen(req, timeout=15) as resp:
+            body = json.load(resp)
+        if body.get("status") == 1:
+            log.info("Pushover sent: %s", title)
+            return True
+        log.error("Pushover rejected the message: %s", body)
+    except Exception as exc:  # noqa: BLE001 - deliberate catch-all
+        log.error("Pushover send failed: %s: %s", type(exc).__name__, exc)
+    return False
+
+
+def probe(cfg: Config) -> tuple[bool, str]:
+    """Check whether Home Assistant's API answers. Returns (ok, detail)."""
+    req = urllib.request.Request(
+        f"{cfg.ha_url}/api/",
+        headers={"Authorization": f"Bearer {cfg.ha_token}"},
+    )
+    try:
+        with urllib.request.urlopen(
+            req, timeout=cfg.timeout, context=ssl.create_default_context()
+        ) as resp:
+            if resp.status != 200:
+                return False, f"HTTP {resp.status}"
+            body = json.load(resp)
+            if "message" not in body:
+                return False, f"unexpected body: {body!r}"
+            return True, body["message"]
+    except urllib.error.HTTPError as exc:
+        # 401 means HA is up but our token is wrong - a real problem, but not an outage.
+        return False, f"HTTP {exc.code}"
+    except Exception as exc:  # noqa: BLE001 - any failure is a failed probe
+        return False, f"{type(exc).__name__}: {exc}"
+
+
+class Sentinel:
+    def __init__(self, cfg: Config) -> None:
+        self.cfg = cfg
+        self.consecutive_failures = 0
+        self.down_since: datetime | None = None
+        self.alerted = False
+        self.last_reminder: datetime | None = None
+        self.last_daily_ok: datetime | None = None
+        self.running = True
+
+    def stop(self, *_: object) -> None:
+        log.info("Shutting down")
+        self.running = False
+
+    def _handle_failure(self, detail: str, now: datetime) -> None:
+        self.consecutive_failures += 1
+        if self.down_since is None:
+            self.down_since = now
+        log.warning(
+            "Probe failed (%d/%d): %s",
+            self.consecutive_failures,
+            self.cfg.fail_threshold,
+            detail,
+        )
+
+        if self.consecutive_failures < self.cfg.fail_threshold:
+            return
+
+        if not self.alerted:
+            send_pushover(
+                self.cfg,
+                "Home Assistant unreachable",
+                f"No API response for {self.consecutive_failures} consecutive checks.\n"
+                f"Down since {self.down_since:%b %d %H:%M}.\nLast error: {detail}",
+                priority=1,
+            )
+            self.alerted = True
+            self.last_reminder = now
+            return
+
+        # Still down - remind periodically so the alert cannot be lost in a scroll.
+        due = self.last_reminder is None or now - self.last_reminder >= timedelta(
+            minutes=self.cfg.remind_minutes
+        )
+        if due:
+            downtime = self._format_duration(now - self.down_since)
+            send_pushover(
+                self.cfg,
+                "Home Assistant still down",
+                f"Unreachable for {downtime}.\nLast error: {detail}",
+                priority=1,
+            )
+            self.last_reminder = now
+
+    def _handle_success(self, detail: str, now: datetime) -> None:
+        if self.alerted and self.down_since is not None:
+            downtime = self._format_duration(now - self.down_since)
+            send_pushover(
+                self.cfg,
+                "Home Assistant back up",
+                f"API responding again after {downtime}.",
+                priority=0,
+            )
+        elif self.consecutive_failures:
+            log.info(
+                "Recovered after %d failed check(s), below alert threshold",
+                self.consecutive_failures,
+            )
+
+        self.consecutive_failures = 0
+        self.down_since = None
+        self.alerted = False
+        self.last_reminder = None
+        log.debug("Probe ok: %s", detail)
+
+    def _maybe_daily_ok(self, now: datetime) -> None:
+        """Send one proof-of-life a day.
+
+        This is the dead-man's switch for the prober itself: it proves the
+        process is alive, the network works, and the Pushover credentials are
+        valid. Silence on the expected day is the signal.
+        """
+        if self.cfg.daily_ok_hour is None or self.alerted:
+            return
+        if now.hour != self.cfg.daily_ok_hour:
+            return
+        if self.last_daily_ok and self.last_daily_ok.date() == now.date():
+            return
+
+        send_pushover(
+            self.cfg,
+            "HA Sentinel daily check",
+            f"Home Assistant reachable. Prober healthy at {now:%b %d %H:%M}.",
+            priority=-1,
+        )
+        self.last_daily_ok = now
+
+    @staticmethod
+    def _format_duration(delta: timedelta) -> str:
+        minutes = int(delta.total_seconds() // 60)
+        if minutes < 60:
+            return f"{minutes} min"
+        hours, minutes = divmod(minutes, 60)
+        if hours < 24:
+            return f"{hours}h {minutes}m"
+        days, hours = divmod(hours, 24)
+        return f"{days}d {hours}h"
+
+    def run(self) -> None:
+        log.info(
+            "HA Sentinel started - probing %s every %ds (alert after %d failures)",
+            self.cfg.ha_url,
+            self.cfg.interval,
+            self.cfg.fail_threshold,
+        )
+        if not self.cfg.can_notify:
+            log.error("PUSHOVER_TOKEN/PUSHOVER_USER are unset - outages will be logged, not sent")
+
+        while self.running:
+            now = datetime.now()
+            ok, detail = probe(self.cfg)
+            if ok:
+                self._handle_success(detail, now)
+                self._maybe_daily_ok(now)
+            else:
+                self._handle_failure(detail, now)
+
+            # Sleep in short slices so a stop signal is honoured promptly.
+            deadline = time.monotonic() + self.cfg.interval
+            while self.running and time.monotonic() < deadline:
+                time.sleep(min(1.0, deadline - time.monotonic()))
+
+
+def main() -> int:
+    logging.basicConfig(
+        level=os.environ.get("LOG_LEVEL", "INFO").upper(),
+        format="%(asctime)s %(levelname)s %(message)s",
+    )
+    try:
+        cfg = Config()
+    except KeyError as exc:
+        log.error("Missing required environment variable: %s", exc)
+        return 1
+
+    sentinel = Sentinel(cfg)
+    signal.signal(signal.SIGTERM, sentinel.stop)
+    signal.signal(signal.SIGINT, sentinel.stop)
+    sentinel.run()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ha_sentinel/ha_sentinel.py
+++ b/ha_sentinel/ha_sentinel.py
@@ -37,8 +37,9 @@ class Config:
         self.timeout = int(os.environ.get("PROBE_TIMEOUT_SECONDS", "10"))
         self.fail_threshold = int(os.environ.get("FAIL_THRESHOLD", "3"))
         self.remind_minutes = int(os.environ.get("REMIND_MINUTES", "30"))
-        # Empty disables the daily proof-of-life message.
-        hour = os.environ.get("DAILY_OK_HOUR", "").strip()
+        # Defaults on: the daily message is the prober's own dead-man's switch,
+        # so losing it must take a deliberate act. An explicit empty value disables.
+        hour = os.environ.get("DAILY_OK_HOUR", "9").strip()
         self.daily_ok_hour = int(hour) if hour else None
 
     @property
@@ -115,6 +116,17 @@ class Sentinel:
         log.info("Shutting down")
         self.running = False
 
+    def _should_record(self, sent_ok: bool) -> bool:
+        """Whether a send attempt should advance notification state.
+
+        A transport failure must NOT advance it: otherwise a dropped alert is
+        silently swallowed and the outage stays unreported until the next
+        reminder. An unconfigured channel is different - it will never succeed,
+        so retrying every cycle would just spam the log instead of honouring the
+        reminder cadence.
+        """
+        return sent_ok or not self.cfg.can_notify
+
     def _handle_failure(self, detail: str, now: datetime) -> None:
         self.consecutive_failures += 1
         if self.down_since is None:
@@ -130,15 +142,16 @@ class Sentinel:
             return
 
         if not self.alerted:
-            send_pushover(
+            sent_ok = send_pushover(
                 self.cfg,
                 "Home Assistant unreachable",
                 f"No API response for {self.consecutive_failures} consecutive checks.\n"
                 f"Down since {self.down_since:%b %d %H:%M}.\nLast error: {detail}",
                 priority=1,
             )
-            self.alerted = True
-            self.last_reminder = now
+            if self._should_record(sent_ok):
+                self.alerted = True
+                self.last_reminder = now
             return
 
         # Still down - remind periodically so the alert cannot be lost in a scroll.
@@ -147,13 +160,14 @@ class Sentinel:
         )
         if due:
             downtime = self._format_duration(now - self.down_since)
-            send_pushover(
+            sent_ok = send_pushover(
                 self.cfg,
                 "Home Assistant still down",
                 f"Unreachable for {downtime}.\nLast error: {detail}",
                 priority=1,
             )
-            self.last_reminder = now
+            if self._should_record(sent_ok):
+                self.last_reminder = now
 
     def _handle_success(self, detail: str, now: datetime) -> None:
         if self.alerted and self.down_since is not None:
@@ -190,13 +204,14 @@ class Sentinel:
         if self.last_daily_ok and self.last_daily_ok.date() == now.date():
             return
 
-        send_pushover(
+        sent_ok = send_pushover(
             self.cfg,
             "HA Sentinel daily check",
             f"Home Assistant reachable. Prober healthy at {now:%b %d %H:%M}.",
             priority=-1,
         )
-        self.last_daily_ok = now
+        if self._should_record(sent_ok):
+            self.last_daily_ok = now
 
     @staticmethod
     def _format_duration(delta: timedelta) -> str:

--- a/tests/test_ha_sentinel.py
+++ b/tests/test_ha_sentinel.py
@@ -145,6 +145,79 @@ def test_daily_ok_suppressed_during_an_outage(cfg, monkeypatch, sent):
     assert sent == []
 
 
+def test_failed_send_is_retried_not_swallowed(cfg, monkeypatch):
+    """A dropped alert must be retried, not silently recorded as delivered.
+
+    Recording an undelivered notification is the exact failure mode that made
+    the previous watchdog useless: state advanced, nothing was sent, and the
+    outage stayed invisible.
+    """
+    attempts = []
+
+    def failing_send(_cfg, title, _message, priority=0):
+        attempts.append(title)
+        return False
+
+    monkeypatch.setattr(ha_sentinel, "send_pushover", failing_send)
+    s = ha_sentinel.Sentinel(cfg)
+    now = datetime(2026, 7, 27, 12, 0)
+
+    for i in range(cfg.fail_threshold):
+        s._handle_failure("boom", now + timedelta(seconds=i))
+
+    assert attempts == ["Home Assistant unreachable"]
+    assert not s.alerted  # not recorded, so the next cycle retries
+
+    s._handle_failure("boom", now + timedelta(seconds=60))
+    assert attempts == ["Home Assistant unreachable"] * 2
+
+
+def test_unconfigured_channel_does_not_retry_every_cycle(monkeypatch, sent):
+    """Without credentials there is nothing to retry, so state must advance."""
+    monkeypatch.setenv("HA_URL", "https://ha.example/")
+    monkeypatch.setenv("HA_TOKEN", "token")
+    monkeypatch.delenv("PUSHOVER_TOKEN", raising=False)
+    monkeypatch.delenv("PUSHOVER_USER", raising=False)
+    monkeypatch.setenv("FAIL_THRESHOLD", "1")
+    cfg = ha_sentinel.Config()
+
+    s = ha_sentinel.Sentinel(cfg)
+    s._handle_failure("boom", datetime(2026, 7, 27, 12, 0))
+
+    assert s.alerted
+
+
+def test_daily_ok_retries_after_a_failed_send(cfg, monkeypatch):
+    monkeypatch.setenv("DAILY_OK_HOUR", "9")
+    cfg = ha_sentinel.Config()
+    calls = []
+
+    def failing_send(_cfg, title, _message, priority=0):
+        calls.append(title)
+        return False
+
+    monkeypatch.setattr(ha_sentinel, "send_pushover", failing_send)
+    s = ha_sentinel.Sentinel(cfg)
+
+    s._maybe_daily_ok(datetime(2026, 7, 27, 9, 0))
+    s._maybe_daily_ok(datetime(2026, 7, 27, 9, 1))
+
+    assert len(calls) == 2  # same day, still retrying
+    assert s.last_daily_ok is None
+
+
+def test_daily_ok_hour_defaults_on(monkeypatch):
+    """The dead-man's switch must be opt-out, not opt-in."""
+    monkeypatch.setenv("HA_URL", "https://ha.example/")
+    monkeypatch.setenv("HA_TOKEN", "token")
+    monkeypatch.delenv("DAILY_OK_HOUR", raising=False)
+
+    assert ha_sentinel.Config().daily_ok_hour == 9
+
+    monkeypatch.setenv("DAILY_OK_HOUR", "")
+    assert ha_sentinel.Config().daily_ok_hour is None
+
+
 @pytest.mark.parametrize(
     ("delta", "expected"),
     [

--- a/tests/test_ha_sentinel.py
+++ b/tests/test_ha_sentinel.py
@@ -172,19 +172,39 @@ def test_failed_send_is_retried_not_swallowed(cfg, monkeypatch):
     assert attempts == ["Home Assistant unreachable"] * 2
 
 
-def test_unconfigured_channel_does_not_retry_every_cycle(monkeypatch, sent):
-    """Without credentials there is nothing to retry, so state must advance."""
+def test_unconfigured_channel_does_not_retry_every_cycle(monkeypatch):
+    """Without credentials there is nothing to retry, so state must advance.
+
+    The fake returns False, matching what the real send_pushover() does when
+    credentials are missing - otherwise this passes whether or not the
+    unconfigured branch actually works.
+    """
     monkeypatch.setenv("HA_URL", "https://ha.example/")
     monkeypatch.setenv("HA_TOKEN", "token")
     monkeypatch.delenv("PUSHOVER_TOKEN", raising=False)
     monkeypatch.delenv("PUSHOVER_USER", raising=False)
     monkeypatch.setenv("FAIL_THRESHOLD", "1")
     cfg = ha_sentinel.Config()
+    assert not cfg.can_notify
 
+    attempts = []
+
+    def unconfigured_send(_cfg, title, _message, priority=0):
+        attempts.append(title)
+        return False
+
+    monkeypatch.setattr(ha_sentinel, "send_pushover", unconfigured_send)
     s = ha_sentinel.Sentinel(cfg)
-    s._handle_failure("boom", datetime(2026, 7, 27, 12, 0))
+    start = datetime(2026, 7, 27, 12, 0)
 
+    s._handle_failure("boom", start)
     assert s.alerted
+    assert len(attempts) == 1
+
+    # Inside the reminder window there must be no second attempt: a missing
+    # credential will never start working, so retrying would only spam the log.
+    s._handle_failure("boom", start + timedelta(minutes=1))
+    assert len(attempts) == 1
 
 
 def test_daily_ok_retries_after_a_failed_send(cfg, monkeypatch):

--- a/tests/test_ha_sentinel.py
+++ b/tests/test_ha_sentinel.py
@@ -1,0 +1,171 @@
+"""Tests for the out-of-band HA liveness prober.
+
+Scope is deliberately the decision logic only - thresholding, escalation,
+recovery and reminder cadence. The network seams (HA probe, Pushover send) were
+verified against real endpoints on the deploy host rather than against mocks,
+because every historical failure in this project lived at a seam where the mock
+and the real payload disagreed.
+"""
+
+import sys
+from datetime import datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "ha_sentinel"))
+
+import ha_sentinel  # noqa: E402
+
+
+@pytest.fixture
+def cfg(monkeypatch):
+    monkeypatch.setenv("HA_URL", "https://ha.example/")
+    monkeypatch.setenv("HA_TOKEN", "token")
+    monkeypatch.setenv("PUSHOVER_TOKEN", "ptoken")
+    monkeypatch.setenv("PUSHOVER_USER", "puser")
+    monkeypatch.setenv("FAIL_THRESHOLD", "3")
+    monkeypatch.setenv("REMIND_MINUTES", "30")
+    monkeypatch.setenv("DAILY_OK_HOUR", "")
+    return ha_sentinel.Config()
+
+
+@pytest.fixture
+def sent(monkeypatch):
+    """Capture outbound notifications instead of sending them."""
+    captured = []
+
+    def fake_send(_cfg, title, message, priority=0):
+        captured.append((title, message, priority))
+        return True
+
+    monkeypatch.setattr(ha_sentinel, "send_pushover", fake_send)
+    return captured
+
+
+def test_below_threshold_does_not_alert(cfg, sent):
+    """A brief blip or a restart must not page."""
+    s = ha_sentinel.Sentinel(cfg)
+    now = datetime(2026, 7, 27, 12, 0)
+
+    for i in range(cfg.fail_threshold - 1):
+        s._handle_failure("boom", now + timedelta(seconds=i))
+
+    assert sent == []
+    assert not s.alerted
+
+
+def test_alerts_once_at_threshold(cfg, sent):
+    s = ha_sentinel.Sentinel(cfg)
+    now = datetime(2026, 7, 27, 12, 0)
+
+    for i in range(cfg.fail_threshold):
+        s._handle_failure("boom", now + timedelta(seconds=i))
+
+    assert len(sent) == 1
+    title, message, priority = sent[0]
+    assert title == "Home Assistant unreachable"
+    assert priority == 1
+    assert "boom" in message
+
+
+def test_reminder_waits_for_the_configured_gap(cfg, sent):
+    s = ha_sentinel.Sentinel(cfg)
+    start = datetime(2026, 7, 27, 12, 0)
+
+    for i in range(cfg.fail_threshold):
+        s._handle_failure("boom", start + timedelta(seconds=i))
+    assert len(sent) == 1
+
+    # The window is measured from when the alert was sent, not from the first
+    # failure, so probe either side of that anchor rather than of `start`.
+    anchor = s.last_reminder
+    assert anchor is not None
+
+    # Still inside the reminder window - must stay quiet.
+    s._handle_failure("boom", anchor + timedelta(minutes=cfg.remind_minutes) - timedelta(seconds=1))
+    assert len(sent) == 1
+
+    # Window elapsed - one reminder, and only one.
+    s._handle_failure("boom", anchor + timedelta(minutes=cfg.remind_minutes))
+    assert len(sent) == 2
+    assert sent[1][0] == "Home Assistant still down"
+
+
+def test_recovery_reports_downtime_and_rearms(cfg, sent):
+    s = ha_sentinel.Sentinel(cfg)
+    start = datetime(2026, 7, 27, 12, 0)
+
+    for i in range(cfg.fail_threshold):
+        s._handle_failure("boom", start + timedelta(seconds=i))
+    s._handle_success("API running.", start + timedelta(minutes=90))
+
+    assert sent[-1][0] == "Home Assistant back up"
+    assert "1h 30m" in sent[-1][1]
+
+    # State must be clean so the next outage alerts again.
+    assert not s.alerted
+    assert s.down_since is None
+    assert s.consecutive_failures == 0
+
+
+def test_recovery_below_threshold_is_silent(cfg, sent):
+    """Recovering from a sub-threshold blip must not send an all-clear."""
+    s = ha_sentinel.Sentinel(cfg)
+    now = datetime(2026, 7, 27, 12, 0)
+
+    s._handle_failure("boom", now)
+    s._handle_success("API running.", now + timedelta(seconds=30))
+
+    assert sent == []
+
+
+def test_daily_ok_sends_once_per_day(cfg, monkeypatch, sent):
+    monkeypatch.setenv("DAILY_OK_HOUR", "9")
+    cfg = ha_sentinel.Config()
+    s = ha_sentinel.Sentinel(cfg)
+
+    s._maybe_daily_ok(datetime(2026, 7, 27, 9, 0))
+    s._maybe_daily_ok(datetime(2026, 7, 27, 9, 30))
+    assert len(sent) == 1
+
+    s._maybe_daily_ok(datetime(2026, 7, 28, 9, 0))
+    assert len(sent) == 2
+
+
+def test_daily_ok_suppressed_during_an_outage(cfg, monkeypatch, sent):
+    """A proof-of-life during a known outage would be actively misleading."""
+    monkeypatch.setenv("DAILY_OK_HOUR", "9")
+    cfg = ha_sentinel.Config()
+    s = ha_sentinel.Sentinel(cfg)
+    s.alerted = True
+
+    s._maybe_daily_ok(datetime(2026, 7, 27, 9, 0))
+
+    assert sent == []
+
+
+@pytest.mark.parametrize(
+    ("delta", "expected"),
+    [
+        (timedelta(seconds=30), "0 min"),
+        (timedelta(minutes=59), "59 min"),
+        (timedelta(minutes=60), "1h 0m"),
+        (timedelta(hours=25), "1d 1h"),
+    ],
+)
+def test_duration_formatting(delta, expected):
+    assert ha_sentinel.Sentinel._format_duration(delta) == expected
+
+
+def test_unconfigured_pushover_is_reported_not_raised(monkeypatch, caplog):
+    """A missing credential must degrade to a loud log, never kill the prober."""
+    monkeypatch.setenv("HA_URL", "https://ha.example/")
+    monkeypatch.setenv("HA_TOKEN", "token")
+    monkeypatch.delenv("PUSHOVER_TOKEN", raising=False)
+    monkeypatch.delenv("PUSHOVER_USER", raising=False)
+    cfg = ha_sentinel.Config()
+
+    assert not cfg.can_notify
+    assert ha_sentinel.send_pushover(cfg, "t", "m") is False
+    assert "WOULD ALERT" in caplog.text


### PR DESCRIPTION
## Why

HA Boss routes every alert channel — persistent notification, mobile push, CLI — through Home Assistant. That makes the single highest-severity event in the system, **Home Assistant itself being down**, the one thing it definitionally cannot report.

HA Sentinel closes exactly that gap and does nothing else. It is the complement to the HA-native device-health automations (`System - Battery Low`, `System - Device Health (Daily Digest)`, `System - Device Offline`), which handle everything *inside* a working HA and cannot go blind while HA is up.

## What it does

Runs on a host that is not the HA machine (blackbox), probes `GET /api/` every 60s, and alerts **Pushover directly**.

- Alerts only after 3 consecutive failures, so a restart or a blip cannot page.
- Re-alerts every 30 min while down, so a real outage cannot be lost in a scroll.
- Reports measured downtime on recovery.
- Sends one low-priority proof-of-life daily.

That daily message is load-bearing, not noise. It proves in one shot that the process is alive, the network works, and the credentials are still valid — **silence on an expected day is the signal**. Every prior outage in this project was a silent self-misconfiguration sitting behind a green light (dead sandbox reported healthy, heartbeat stamping while the WebSocket was dead 3 days, self-test PASS while monitoring nothing). A watchdog needs a liveness signal that a stopped component cannot fake.

## Design choices worth reviewing

- **Standard library only.** No dependencies, no database, no container.
- **systemd, not Docker**, and the unit deliberately has no `After=docker.service`: the watchdog must survive Docker dying. Fewer layers beneath it than the thing it watches.
- **TLS verifies normally.** HA Boss used `CERT_NONE`; that was unnecessary and is not carried over.
- A wrong/expired token surfaces as `HTTP 401` rather than "unreachable" — a real problem, but named accurately.

## Testing

Unit tests cover the decision logic only: threshold escalation, sub-threshold silence, reminder cadence, recovery + re-arm, daily-OK once-per-day and its suppression during an outage, and duration formatting.

The network seams were verified against **real endpoints on the deploy host**, not mocks — healthy probe against live HA, outage escalation, reminder, recovery with downtime, and a `kill -9` that systemd restarted 15s later. That split is deliberate: every historical failure in this repo lived at a seam where a mock and the real payload disagreed (REST shape fed to a WebSocket parser, a constructor arg not passed, an exception type never raised). Mocking those seams here would repeat the mistake.

Full suite: **512 passed, 1 failed** — the failure is the known pre-existing DST-sensitive `test_format_time_ago_naive_datetime`, which fails in CDT and passes in UTC CI. `black`, `ruff`, and `mypy ha_boss` all clean.

## Note

`.gitignore` had a blanket `*.service` rule that was silently swallowing the shipped systemd unit. Scoped it with a negation rather than force-adding, so future edits to the unit are not silently dropped.

## Not included

Decommissioning the HA Boss monitor-and-notify package and the HA-side automations that supervise it. That is a follow-up, deliberately after these alerts are confirmed working in production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added HA Sentinel to continuously monitor Home Assistant reachability and send Pushover alerts.
  * Alerts after repeated failures, with periodic outage reminders and a one-time recovery notification.
  * Optional once-per-day proof-of-life message with configurable probe/reminder timing.
  * Added a system service to run the monitor with automatic restart and improved security hardening.
* **Documentation**
  * Added setup/configuration and expected-behavior documentation for HA Sentinel, including verified runtime notes.
* **Tests**
  * Added coverage for alert thresholds, reminders, recovery downtime reporting, daily rules, and failure/edge cases.
* **Chores**
  * Updated ignore rules so the shipped Sentinel unit/service files remain tracked.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->